### PR TITLE
Fix neuron point selection in Horta 3D

### DIFF
--- a/modules/HortaTracer/src/main/java/org/janelia/horta/controller/HortaManager.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/controller/HortaManager.java
@@ -156,6 +156,8 @@ public class HortaManager {
             renderer.clearNeuronReconstructions();
 
             if (TmModelManager.getInstance().getCurrentWorkspace() != null) {
+                workspace = TmModelManager.getInstance().getCurrentWorkspace();
+                guiManager.setDefaultWorkspace(workspace);
                 for (TmNeuronMetadata neuron : NeuronManager.getInstance().getNeuronList()) {
                     renderer.addNeuronActors(neuron);
                 }


### PR DESCRIPTION
There is a bug in Horta 3D where it is not possible to select neurons in Horta 3D if the "Open 3D" checkbox is toggled on before loading a workspace. 

**Steps to reproduce**:
1) Open the workstation
3) Open a sample (optional)
2) Open Horta Control Center
3) Click the "Open 3D" checkbox
4) Either load an existing workspace or create a new workspace from a sample
5) Create a new neuron and add a couple points
6) Hover over a point to trigger node highlighting -- fails

**Expected behavior** 
When hovering the mouse over a neuron node, the node should become highlighted, which enables selecting the point. 

**Current workaround**
Either load or create a workspace before enabling the "Open 3D" checkbox

**Source of the issue**
Clicking the "open 3D" checkbox in Horta Control Center before creating or opening a workspace will create a `NeuronTracerTopComponent` with a `HortaManager` pointing to a `null` workspace, which causes neuron selection to fail after loading or creating a workspace, see https://github.com/JaneliaSciComp/workstation/blob/6ea8dcb5816011fc1566459fc05022091bc82935/modules/HortaTracer/src/main/java/org/janelia/horta/controller/HortaManager.java#L56-L63

This PR fixes this issue by updating the `workspace` and `guiManager` instance fields of the `HortaManager` with the current workspace from the `TmModelManager` in the `HortaManager.workspaceLoaded` event subscriber, which is called whenever a workspace is loaded or created.