### PR TITLE
Fix neuron edit actions in Horta 3D context menu

### DIFF
--- a/modules/ViewerController/src/main/java/org/janelia/workstation/controller/NeuronManager.java
+++ b/modules/ViewerController/src/main/java/org/janelia/workstation/controller/NeuronManager.java
@@ -447,6 +447,15 @@ public class NeuronManager implements DomainObjectSelectionSupport {
         });
     }
 
+    public synchronized void renameNeuron(TmNeuronMetadata neuron, String name) throws Exception {
+        TmModelManager.getInstance().getNeuronHistory().checkBackup(neuron);
+        neuron.setName(name);
+        this.neuronModel.saveNeuronData(neuron);
+        log.info("Neuron was renamed: "+neuron);
+
+        SwingUtilities.invokeLater(() -> fireNeuronRenamed(neuron));
+    }
+
     /**
      * change the ownership of the input neuron
      */

--- a/modules/ViewerController/src/main/java/org/janelia/workstation/controller/action/NeuronDeleteAction.java
+++ b/modules/ViewerController/src/main/java/org/janelia/workstation/controller/action/NeuronDeleteAction.java
@@ -64,7 +64,7 @@ public class NeuronDeleteAction extends EditAction {
                 "Delete neuron?",
                 JOptionPane.OK_CANCEL_OPTION);
         if (ans == JOptionPane.OK_OPTION) {
-            NeuronManager.getInstance().deleteCurrentNeuron();
+            NeuronManager.getInstance().deleteNeuron(targetNeuron);
         }
         this.targetNeuron = null;
     }

--- a/modules/ViewerController/src/main/java/org/janelia/workstation/controller/action/NeuronRenameAction.java
+++ b/modules/ViewerController/src/main/java/org/janelia/workstation/controller/action/NeuronRenameAction.java
@@ -60,7 +60,7 @@ public class NeuronRenameAction extends EditAction {
         SimpleWorker renamer = new SimpleWorker() {
             @Override
             protected void doStuff() throws Exception {
-                annotationModel.renameCurrentNeuron(neuronName);
+                annotationModel.renameNeuron(targetNeuron, neuronName);
             }
 
             @Override


### PR DESCRIPTION
There is a bug with two neuron editing functions in the Horta 3D right-click menu:
- Rename
- Delete

These functions will operate on the neuron that is currently selected, instead of the neuron that was right-clicked.

Steps to reproduce:
1) Open a workspace
2) Create two neurons "Neuron 1" and "Neuron 2" and add a couple points to each
3) Left click a point on Neuron 1 to select that neuron
4) Hover over a point on Neuron 2 and right-click to bring up the context menu
5) Choose Delete and press OK
6) Neuron 1 is deleted instead of Neuron 2

The same occurs with the Rename function.

Fix proposed:
- use `NeuronManager.deleteNeuron` instead of `NeuronManager.deleteCurrentNeuron` in `NeuronDeleteAction`
- create a `NeuronManager.renameNeuron` function and use that in `NeuronRenameAction`
