### PR TITLE
OME-Zarr initial support.

### DIFF
--- a/modules/GLViewerTools/src/main/java/org/janelia/gltools/texture/Texture3d.java
+++ b/modules/GLViewerTools/src/main/java/org/janelia/gltools/texture/Texture3d.java
@@ -173,6 +173,39 @@ public class Texture3d extends BasicTexture implements GL3Resource {
         }
     }
 
+    /**
+     * Safe version of internal loadStack() for raster images that are already loaded/parsed elsewhere.
+     * @param slices stack of Raster images
+     * @param colorModel Raster image color model
+     * @return true if stack is successfully loaded
+     */
+    public boolean loadRasterSlices(Raster[] slices, ColorModel colorModel) {
+        try {
+            PerformanceTimer timer = new PerformanceTimer();
+
+            if (slices == null) {
+                return false;
+            }
+
+            if (slices.length > 0) {
+                depth = slices.length;
+                width = slices[0].getWidth();
+                height = slices[0].getHeight();
+
+                loadStack(slices, colorModel);
+
+                float t1 = timer.reportMsAndRestart();
+                LOG.info(">>> loadRasterSlices() total time = {} ms", (t1));
+                return true;
+            } else {
+                return false;
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("Unable to parse", e);
+        }
+    }
+
     private void allocatePixels() {
         int byteCount = numberOfComponents * bytesPerIntensity * width * height * depth;
         pixelBytes = new byte[byteCount];

--- a/modules/HortaTracer/pom.xml
+++ b/modules/HortaTracer/pom.xml
@@ -16,7 +16,6 @@
     <packaging>nbm</packaging>
 
     <dependencies>
-        
         <!-- CommonLibraries -->
         <dependency>
             <groupId>org.janelia.workstation</groupId>
@@ -73,6 +72,13 @@
         <dependency>
             <groupId>org.janelia.workstation</groupId>
             <artifactId>scenegraph</artifactId>
+        </dependency>
+
+        <!-- OME-Zarr -->
+        <dependency>
+            <groupId>org.aind</groupId>
+            <artifactId>jomezarr</artifactId>
+            <version>1.2.10</version>
         </dependency>
         
         <!-- NetBeans Modules --> 

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/KtxBlockMenuBuilder.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/KtxBlockMenuBuilder.java
@@ -9,6 +9,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JPopupMenu;
 
 import org.janelia.horta.actions.LoadHortaTileAtFocusAction;
+import org.janelia.horta.actors.OmeZarrVolumeActor;
 import org.janelia.horta.actors.TetVolumeActor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,7 +62,7 @@ class KtxBlockMenuBuilder {
             @Override
             public void actionPerformed(ActionEvent e) {
                 TetVolumeActor.getInstance().clearAllBlocks();
-                TetVolumeActor.getInstance().clearAllBlocks();
+                OmeZarrVolumeActor.getInstance().clearAllBlocks();
                 nttc.getNeuronMPRenderer().clearVolumeActors();
                 nttc.clearAllTiles();
             }

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/NeuronTracerTopComponent.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/NeuronTracerTopComponent.java
@@ -1,6 +1,9 @@
 package org.janelia.horta;
 
 import java.awt.*;
+
+import org.apache.commons.lang.StringUtils;
+import org.janelia.model.domain.enums.FileType;
 import java.awt.datatransfer.*;
 import java.awt.dnd.*;
 import java.awt.event.*;
@@ -35,6 +38,10 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.jogamp.opengl.util.awt.AWTGLReadBufferUtil;
 
 import org.janelia.geometry3d.ObservableInterface;
+import org.janelia.horta.actors.OmeZarrVolumeActor;
+import org.janelia.horta.blocks.OmeZarrBlockTileSource;
+import org.janelia.horta.loader.*;
+import org.janelia.horta.volume.*;
 import org.janelia.model.domain.enums.FileType;
 import org.janelia.workstation.common.actions.CopyToClipboardAction;
 import org.janelia.workstation.controller.dialog.NeuronColorDialog;
@@ -171,6 +178,8 @@ public final class NeuronTracerTopComponent extends TopComponent
     private StaticVolumeBrickSource volumeSource;
     // New way for loading ktx tiles
     private KtxOctreeBlockTileSource ktxSource;
+    // New way for loading ome zarr tiles
+    private OmeZarrBlockTileSource omeZarrSource;
 
     private CenterCrossHairActor crossHairActor;
     private ScaleBar scaleBar = new ScaleBar();
@@ -329,6 +338,15 @@ public final class NeuronTracerTopComponent extends TopComponent
             }
         });
 
+        OmeZarrVolumeActor.getInstance().setVolumeState(volumeState);
+        OmeZarrVolumeActor.getInstance().getDynamicTileUpdateObservable().addObserver(new Observer() {
+            @Override
+            public void update(Observable o, Object arg) {
+                getNeuronMPRenderer().setIntensityBufferDirty();
+                redrawNow();
+            }
+        });
+
         neuronMPRenderer = setUpActors();
 
         hortaManager = new HortaManager(this, getNeuronMPRenderer(), tracingInteractor);
@@ -434,6 +452,7 @@ public final class NeuronTracerTopComponent extends TopComponent
         // Don't load both ktx and raw tiles...
         if (volumeSource != null) {
             setKtxSource(null);
+            setOmeZarrSource(null);
         }
     }
 
@@ -529,6 +548,14 @@ public final class NeuronTracerTopComponent extends TopComponent
                 vantage.setRotationInGround(new Rotation().setFromQuaternion(q));
             } else {
                 vantage.setRotationInGround(vantage.getDefaultRotation());
+            }
+
+            TmSample tmSample = TmModelManager.getInstance().getCurrentSample();
+            if (tmSample != null) {
+                String zarrPath = tmSample.getFiles().get(FileType.LargeVolumeZarr);
+                if (zarrPath != null && !StringUtils.isBlank(zarrPath)) {
+                    setCubifyVoxels(false);
+                }
             }
 
             currentSource = TmModelManager.getInstance().getTileLoader().getUrl().toString();
@@ -820,6 +847,10 @@ public final class NeuronTracerTopComponent extends TopComponent
 
     private ImageColorModel imageColorModel = new ImageColorModel(65535, 3);
 
+    public ImageColorModel getImageColorModel() {
+        return imageColorModel;
+    }
+
     public void loadStartupPreferences() {
         Preferences prefs = NbPreferences.forModule(getClass());
 
@@ -946,6 +977,7 @@ public final class NeuronTracerTopComponent extends TopComponent
         });
 
         TetVolumeActor.getInstance().setHortaVantage(vantage);
+        OmeZarrVolumeActor.getInstance().setHortaVantage(vantage);
 
         // Set default colors to mouse light standard...
         imageColorModel.getChannel(0).setColor(Color.green);
@@ -1004,6 +1036,13 @@ public final class NeuronTracerTopComponent extends TopComponent
         neuronTraceLoader.loadTileAtCurrentFocus(volumeSource);
     }
 
+    public boolean loadDroppedOmeZarr(String sourceName) throws IOException {
+        setOmeZarrSource(new OmeZarrBlockTileSource(null, getImageColorModel()).init(sourceName));
+        Vector3 focus = sceneWindow.getCamera().getVantage().getFocusPosition();
+        neuronTraceLoader.loadOmeZarrTileAtLocation(getOmeZarrSource(), focus, true);
+        return true;
+    }
+
     private void setupDragAndDropYml() {
         final DroppedFileHandler droppedFileHandler = new DroppedFileHandler();
         droppedFileHandler.addLoader(new GZIPFileLoader());
@@ -1013,6 +1052,7 @@ public final class NeuronTracerTopComponent extends TopComponent
         droppedFileHandler.addLoader(new TilebaseYamlLoader(this));
         droppedFileHandler.addLoader(new ObjMeshLoader(this));
         droppedFileHandler.addLoader(new HortaKtxLoader(this.getNeuronMPRenderer()));
+        droppedFileHandler.addLoader(new OmeZarrLoader(this));
 
         // Allow user to drop tilebase.cache.yml on this window
         setDropTarget(new DropTarget(this, new DropTargetListener() {
@@ -1209,6 +1249,7 @@ public final class NeuronTracerTopComponent extends TopComponent
                             volumeCache.toggleUpdateCache();
                             item.setSelected(doesUpdateVolumeCache());
                             TetVolumeActor.getInstance().setAutoUpdate(doesUpdateVolumeCache());
+                            OmeZarrVolumeActor.getInstance().setAutoUpdate(doesUpdateVolumeCache());
                         }
                     });
                 }
@@ -2022,6 +2063,7 @@ public final class NeuronTracerTopComponent extends TopComponent
     public void clearAllTiles() {
         // this is a workaround for clearing RAW tiles until we can clean up the controllers for Horta
         TetVolumeActor.getInstance().setAutoUpdate(false);
+        OmeZarrVolumeActor.getInstance().setAutoUpdate(false);
         reloadSampleLocation();
     }
 
@@ -2169,6 +2211,21 @@ public final class NeuronTracerTopComponent extends TopComponent
         TetVolumeActor.getInstance().setKtxTileSource(ktxSource);
         // Don't load both ktx and raw tiles at the same time
         if (ktxSource != null) {
+            setOmeZarrSource(null);
+            setVolumeSource(null);
+        }
+    }
+
+    OmeZarrBlockTileSource getOmeZarrSource() {
+        return omeZarrSource;
+    }
+
+    void setOmeZarrSource(OmeZarrBlockTileSource omeZarrSource){
+        this.omeZarrSource = omeZarrSource;
+        OmeZarrVolumeActor.getInstance().setOmeZarrTileSource(omeZarrSource);
+        // Don't load ktx and omezarr or raw tiles at the same time
+        if (omeZarrSource != null) {
+            setKtxSource(null);
             setVolumeSource(null);
         }
     }
@@ -2241,7 +2298,8 @@ public final class NeuronTracerTopComponent extends TopComponent
 
     boolean isPreferKtx() {
         TmSample tmSample = TmModelManager.getInstance().getCurrentSample();
-        if (tmSample.getFiles().containsKey(FileType.LargeVolumeZarr)) {
+
+        if (this.omeZarrSource != null || (tmSample != null && tmSample.getFiles().containsKey(FileType.LargeVolumeZarr))) {
             return false;
         } else {
             return true;

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/TracingInteractor.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/TracingInteractor.java
@@ -788,16 +788,19 @@ public class TracingInteractor extends MouseAdapter
             Point optimizedPoint = optimizePosition(hoverPoint);
             Vector3 cursorXyz = volumeProjection.worldXyzForScreenXy(optimizedPoint);
             Matrix m2v = TmModelManager.getInstance().getMicronToVoxMatrix();
-            Jama.Matrix micLoc = new Jama.Matrix(new double[][]{
-                    {cursorXyz.getX(),},
-                    {cursorXyz.getY(),},
-                    {cursorXyz.getZ(),},
-                    {1.0,},});
-            // NeuronVertex API requires coordinates in micrometers
-            Jama.Matrix voxLoc = m2v.times(micLoc);
-            Vector3 newLoc = new Vector3(voxLoc.get(0, 0), voxLoc.get(1, 0),
-                    voxLoc.get(2, 0));
-            setDensityCursor(newLoc, optimizedPoint);
+
+            if (m2v != null) {
+                Jama.Matrix micLoc = new Jama.Matrix(new double[][]{
+                        {cursorXyz.getX(),},
+                        {cursorXyz.getY(),},
+                        {cursorXyz.getZ(),},
+                        {1.0,},});
+                // NeuronVertex API requires coordinates in micrometers
+                Jama.Matrix voxLoc = m2v.times(micLoc);
+                Vector3 newLoc = new Vector3(voxLoc.get(0, 0), voxLoc.get(1, 0),
+                        voxLoc.get(2, 0));
+                setDensityCursor(newLoc, optimizedPoint);
+            }
         }
         else {
             if (clearDensityCursor())

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/actions/LoadHortaTileAtFocusAction.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/actions/LoadHortaTileAtFocusAction.java
@@ -34,7 +34,6 @@ public final class LoadHortaTileAtFocusAction implements ActionListener {
     @Override
     public void actionPerformed(ActionEvent e) {
         try {
-            LOG.info("Load KTX Central Tile Action invoked");
             context.loadPersistentTileAtFocus();
         } catch (IOException ex) {
             LOG.info("Tile load failed", ex);

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/actors/OmeZarrMesh.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/actors/OmeZarrMesh.java
@@ -1,0 +1,54 @@
+package org.janelia.horta.actors;
+
+import Jama.Matrix;
+import org.janelia.geometry3d.*;
+import org.janelia.horta.blocks.OmeZarrBlockTileKey;
+
+public class OmeZarrMesh extends MeshGeometry implements VolumeTextureMesh {
+    private final OmeZarrBlockTileKey data;
+    private Matrix4 transformWorldToTexCoord;
+
+    public OmeZarrMesh(OmeZarrBlockTileKey data) {
+        this.data = data;
+        // Enumerate 8 corners of tile
+        // NOTE: These are actual corners, not axis-aligned bounding box
+        int cornerCount = 0;
+        for (ConstVector3 corner : data.getCornerLocations()) {
+            // spatial coordinates
+            Vertex v = addVertex(corner);
+
+            // texture coordinates
+            // X texture coordinates alternate
+            float tx = (float) cornerCount % 2;
+            float ty = (float) (cornerCount / 2) % 2;
+            float tz = (float) (cornerCount / 4) % 2;
+            v.setAttribute("texCoord", new Vector3(tx, ty, tz));
+
+            cornerCount += 1;
+        }
+
+        addFace(new int[]{0, 2, 3, 1}); // rear
+        addFace(new int[]{4, 5, 7, 6}); // front
+        addFace(new int[]{1, 3, 7, 5}); // right
+        addFace(new int[]{0, 4, 6, 2}); // left
+        addFace(new int[]{2, 6, 7, 3}); // top
+        addFace(new int[]{0, 1, 5, 4}); // bottom
+
+        notifyObservers();
+    }
+
+    @Override
+    public Matrix4 getTransformWorldToTexCoord() {
+        if (transformWorldToTexCoord == null) {
+            Matrix m = data.getStageCoordToTexCoord();
+            transformWorldToTexCoord = new Matrix4(m);
+        }
+
+        return transformWorldToTexCoord;
+    }
+
+    @Override
+    public float getMinResolution() {
+        return (float) data.getResolutionMicrometers();
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/actors/OmeZarrVolumeActor.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/actors/OmeZarrVolumeActor.java
@@ -1,0 +1,174 @@
+package org.janelia.horta.actors;
+
+import org.janelia.geometry3d.*;
+import org.janelia.gltools.BasicGL3Actor;
+import org.janelia.gltools.GL3Actor;
+import org.janelia.gltools.material.DepthSlabClipper;
+import org.janelia.gltools.texture.Texture2d;
+import org.janelia.horta.blocks.*;
+import org.janelia.horta.volume.VolumeMipMaterial;
+import org.janelia.workstation.controller.model.color.ImageColorModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.media.opengl.GL3;
+import javax.media.opengl.GL4;
+import java.util.ArrayList;
+import java.util.List;
+
+public class OmeZarrVolumeActor extends BasicGL3Actor implements DepthSlabClipper {
+    private static final Logger LOG = LoggerFactory.getLogger(OmeZarrVolumeActor.class);
+
+    private static OmeZarrVolumeActor singletonInstance;
+
+    // Singleton access
+    static public OmeZarrVolumeActor getInstance() {
+        if (singletonInstance == null)
+            singletonInstance = new OmeZarrVolumeActor();
+        return singletonInstance;
+    }
+
+    private Texture2d opaqueDepthTexture = null;
+    private float zNearRelative = 0.10f;
+    private float zFarRelative = 100.0f; // relative z clip planes
+    private ImageColorModel brightnessModel;
+
+    private VolumeMipMaterial.VolumeState volumeState = new VolumeMipMaterial.VolumeState();
+
+    private OmeZarrBlockTileSource source;
+    private final OmeZarrTileCache dynamicTiles = new OmeZarrTileCache(null);
+    private BlockChooser<OmeZarrBlockTileKey, OmeZarrBlockTileSource> chooser;
+    private BlockDisplayUpdater<OmeZarrBlockTileKey, OmeZarrBlockTileSource> blockDisplayUpdater;
+
+    private OmeZarrVolumeActor() {
+        super(null);
+        chooser = new OmeZarrBlockChooser();
+        blockDisplayUpdater = new BlockDisplayUpdater<>(chooser);
+        initBlockStrategy(chooser);
+        blockDisplayUpdater.getDisplayChangeObservable().addObserver((o, arg) -> dynamicTiles.updateDesiredTiles(blockDisplayUpdater.getDesiredBlocks()));
+        dynamicTiles.getDisplayChangeObservable().addObserver(((o, arg) -> {
+            List<Object3d> list = new ArrayList<>();
+            getChildren().forEach(c -> {
+                if (!dynamicTiles.getDisplayedActors().contains(c)) {
+                    list.add(c);
+                }
+            });
+            getChildren().removeAll(list);
+            dynamicTiles.getDisplayedActors().forEach(a -> {
+                if (!getChildren().contains(a)) {
+                    addPersistentBlock(a);
+                }
+            });
+        }));
+    }
+
+    private void initBlockStrategy(BlockChooser<OmeZarrBlockTileKey, OmeZarrBlockTileSource> chooser) {
+        dynamicTiles.setBlockStrategy(chooser);
+        blockDisplayUpdater.setBlockChooser(chooser);
+    }
+
+    public void setAutoUpdate(boolean updateCache) {
+        blockDisplayUpdater.setAutoUpdate(updateCache);
+    }
+
+    public VolumeMipMaterial.VolumeState getVolumeState() {
+        return volumeState;
+    }
+
+    public Object3d addPersistentBlock(Object3d child) {
+        return addChild(child);
+    }
+
+    @Override
+    public Object3d addChild(Object3d child) {
+        if (child instanceof DepthSlabClipper) {
+            ((DepthSlabClipper) child).setOpaqueDepthTexture(opaqueDepthTexture);
+            ((DepthSlabClipper) child).setRelativeSlabThickness(zNearRelative, zFarRelative);
+        }
+        return super.addChild(child);
+    }
+
+    public void addTransientBlock(BlockTileKey key) {
+        dynamicTiles.addDesiredTile((OmeZarrBlockTileKey) key);
+    }
+
+    public void setVolumeState(VolumeMipMaterial.VolumeState volumeState) {
+        this.volumeState = volumeState;
+    }
+
+    public void setBrightnessModel(ImageColorModel brightnessModel) {
+        this.brightnessModel = brightnessModel;
+    }
+
+    public void clearAllBlocks() {
+        dynamicTiles.clearAllTiles();
+        getChildren().clear();
+    }
+
+    public void setHortaVantage(Vantage vantage) {
+        blockDisplayUpdater.setVantage(vantage);
+    }
+
+    public void setOmeZarrTileSource(OmeZarrBlockTileSource source) {
+        dynamicTiles.setSource(source);
+        blockDisplayUpdater.setBlockTileSource(source);
+        this.source = source;
+    }
+
+    public ObservableInterface getDynamicTileUpdateObservable() {
+        return dynamicTiles.getDisplayChangeObservable();
+    }
+
+    @Override
+    public void setOpaqueDepthTexture(Texture2d opaqueDepthTexture) {
+        this.opaqueDepthTexture = opaqueDepthTexture;
+
+        getChildren().forEach(c -> {
+            if (c instanceof DepthSlabClipper) {
+                ((DepthSlabClipper) c).setOpaqueDepthTexture(opaqueDepthTexture);
+            }
+        });
+    }
+
+    @Override
+    public void setRelativeSlabThickness(float zNear, float zFar) {
+        zNearRelative = zNear;
+        zFarRelative = zFar;
+
+        getChildren().forEach(c -> {
+            if (c instanceof DepthSlabClipper) {
+                ((DepthSlabClipper) c).setRelativeSlabThickness(zNear, zFar);
+            }
+        });
+    }
+
+    public void display(GL3 gl, AbstractCamera camera, Matrix4 parentModelViewMatrix) {
+        if (!isVisible())
+            return;
+        if (!isInitialized) init(gl);
+        if (getChildren() == null)
+            return;
+
+        Object3d[] children = getChildren().toArray(new Object3d[0]);
+        if (children.length < 1)
+            return;
+
+        gl.glEnable(GL3.GL_BLEND);
+        // Max intensity
+        ((GL4) gl).glBlendEquationi(0, GL4.GL_MAX); // RGBA color target
+        // Always use Maximum for blending secondary render target
+        ((GL4) gl).glBlendEquationi(1, GL4.GL_MAX); // core intensity/depth target
+
+        Matrix4 modelViewMatrix = parentModelViewMatrix;
+        if (modelViewMatrix == null)
+            modelViewMatrix = camera.getViewMatrix();
+        Matrix4 localMatrix = getTransformInParent();
+        if (localMatrix != null)
+            modelViewMatrix = new Matrix4(modelViewMatrix).multiply(localMatrix);
+        for (Object3d child : children) {
+            if (child instanceof GL3Actor) {
+                ((GL3Actor) child).display(gl, camera, modelViewMatrix);
+            }
+        }
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/actors/OmeZarrVolumeMeshActor.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/actors/OmeZarrVolumeMeshActor.java
@@ -1,0 +1,75 @@
+package org.janelia.horta.actors;
+
+import org.janelia.geometry3d.AbstractCamera;
+import org.janelia.geometry3d.ConstVector3;
+import org.janelia.geometry3d.Matrix4;
+import org.janelia.geometry3d.Vector4;
+import org.janelia.gltools.material.DepthSlabClipper;
+import org.janelia.gltools.texture.Texture2d;
+import org.janelia.gltools.texture.Texture3d;
+import org.janelia.gltools.MeshActor;
+import org.janelia.horta.blocks.BlockTileResolution;
+import org.janelia.horta.blocks.OmeZarrBlockTileKey;
+import org.janelia.horta.blocks.OmeZarrBlockTileSource;
+import org.janelia.horta.volume.VolumeMipMaterial;
+import org.janelia.workstation.controller.model.color.ImageColorModel;
+
+import javax.media.opengl.GL3;
+import java.io.IOException;
+
+public class OmeZarrVolumeMeshActor extends MeshActor implements SortableBlockActor, DepthSlabClipper {
+    private final OmeZarrVolumeMeshActor.MeshMaterial meshMaterial;
+
+    private final Vector4 homogeneousCentroid;
+
+    private BlockTileResolution resolution;
+
+    public OmeZarrVolumeMeshActor(OmeZarrBlockTileSource source, OmeZarrBlockTileKey tile, VolumeMipMaterial.VolumeState volumeState, int colorChannel) throws IOException {
+        super(new OmeZarrMesh(tile), new OmeZarrVolumeMeshActor.MeshMaterial(source, tile, source.getColorModel(), volumeState, colorChannel), null);
+
+        this.meshMaterial = (OmeZarrVolumeMeshActor.MeshMaterial)getMaterial();
+
+        ConstVector3 centroid = tile.getCentroid();
+
+        this.homogeneousCentroid= new Vector4(centroid.getX(), centroid.getY(), centroid.getZ(), 1.0f);
+    }
+
+    @Override
+    public void display(GL3 gl, AbstractCamera camera, Matrix4 parentModelViewMatrix)
+    {
+        super.display(gl, camera, parentModelViewMatrix); // display child objects
+    }
+
+    public void setOpaqueDepthTexture(Texture2d depthTexture) {
+        meshMaterial.setOpaqueDepthTexture(depthTexture);
+    }
+
+    public void setRelativeSlabThickness(float zNear, float zFar) {
+        meshMaterial.setRelativeSlabThickness(zNear, zFar);
+    }
+
+    @Override
+    public Vector4 getHomogeneousCentroid() {
+        return homogeneousCentroid;
+    }
+
+    @Override
+    public BlockTileResolution getResolution() {
+        return null;
+    }
+
+    private static class MeshMaterial extends VolumeMipMaterial {
+        private MeshMaterial(OmeZarrBlockTileSource source, OmeZarrBlockTileKey tile, ImageColorModel imageColorModel, VolumeState volumeState, int colorChannel) throws IOException {
+            super(safeLoadData(source, tile, colorChannel), imageColorModel);
+            setVolumeState(volumeState);
+        }
+
+        private static Texture3d safeLoadData(OmeZarrBlockTileSource source, OmeZarrBlockTileKey tile, int colorChannel) throws IOException {
+            Texture3d brick = source.loadBrick(tile, colorChannel);
+            if (brick == null) {
+                throw new IOException("Load was interrupted");
+            }
+            return brick;
+        }
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockChooser.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockChooser.java
@@ -1,0 +1,165 @@
+package org.janelia.horta.blocks;
+
+import org.janelia.geometry3d.ConstVector3;
+import org.janelia.geometry3d.Vantage;
+import org.janelia.geometry3d.Vector3;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.*;
+
+public class OmeZarrBlockChooser implements BlockChooser<OmeZarrBlockTileKey, OmeZarrBlockTileSource> {
+    private static final Logger LOG = LoggerFactory.getLogger(OmeZarrBlockChooser.class);
+
+    private List<Float> zoomLevels = new ArrayList<>();
+    private double BLOCK_WIDTH_ACROSS_VIEWPORT = 2.35;
+    private int MAX_SIMULTANEOUS_BLOCKS = 14;
+
+    @Override
+    public List<OmeZarrBlockTileKey> chooseBlocks(OmeZarrBlockTileSource source, ConstVector3 focus, ConstVector3 previousFocus, Vantage vantage) {
+        return chooseBlocks(source, focus, previousFocus, vantage, 8);
+    }
+
+    public List<OmeZarrBlockTileKey> chooseBlocks(OmeZarrBlockTileSource source, ConstVector3 focus, ConstVector3 previousFocus, Vantage vantage, int maxCount) {
+        if (zoomLevels.size() == 0) {
+            initBlockSizes(source);
+        }
+
+        ArrayList<OmeZarrBlockResolution> resolutions = source.getResolutions();
+
+        // Find up to eight closest blocks adjacent to focus
+        int zoomIndex = resolutions.size() - 1;
+
+        float screenHeight = vantage.getSceneUnitsPerViewportHeight();
+
+        while (zoomIndex >= 0) {
+            if (screenHeight < zoomLevels.get(zoomIndex)) {
+                break;
+            }
+
+            zoomIndex--;
+        }
+
+        if (zoomIndex < 0) {
+            zoomIndex = 0;
+        }
+
+        OmeZarrBlockResolution resolution = resolutions.get(zoomIndex);
+
+        ConstVector3 blockSize = source.getBlockSize(resolution);
+
+        float dxa[] = new float[]{
+                0f,
+                -blockSize.getX(),
+                +blockSize.getX()};
+        float dya[] = new float[]{
+                0f,
+                -blockSize.getY(),
+                +blockSize.getY()};
+        float dza[] = new float[]{
+                0f,
+                -blockSize.getZ(),
+                +blockSize.getZ()};
+
+        List<OmeZarrBlockTileKey> neighboringBlocks = new ArrayList<>();
+
+        // Enumerate all 27 nearby blocks
+        for (float dx : dxa) {
+            for (float dy : dya) {
+                for (float dz : dza) {
+                    ConstVector3 location = focus.plus(new Vector3(dx, dy, dz));
+                    OmeZarrBlockTileKey tileKey = source.getBlockKeyAt(location, resolution);
+                    if (tileKey == null) {
+                        continue;
+                    }
+                    if (!neighboringBlocks.contains(tileKey)) {
+                        neighboringBlocks.add(tileKey);
+                    }
+                }
+            }
+        }
+
+        // Sort the blocks strictly by distance to focus
+        Collections.sort(neighboringBlocks, new OmeZarrBlockChooser.BlockComparator(focus));
+
+        // Return only the closest 8 blocks
+        List<OmeZarrBlockTileKey> result = new ArrayList<>();
+        int listLen = Math.min(maxCount, neighboringBlocks.size());
+        for (int i = 0; i < listLen; ++i) {
+            result.add(neighboringBlocks.get(i));
+        }
+
+        return result;
+    }
+
+    @Override
+    public Map<BlockTileKey, BlockTileData> chooseObsoleteTiles(Map<BlockTileKey, BlockTileData> currentTiles, Map<BlockTileKey, BlockTileData> desiredTiles, BlockTileKey finishedTile) {
+
+        Map<BlockTileKey, BlockTileData> obsoleteTiles = new HashMap<>();
+        SortedMap<Float, BlockTileKey> sortedCurrZoomTiles = new TreeMap<>();
+        ConstVector3 currFocus = finishedTile.getCentroid();
+        int zoomLevel = ((OmeZarrBlockTileKey) finishedTile).getKeyDepth();
+
+        Iterator<BlockTileKey> iter = currentTiles.keySet().iterator();
+        boolean blockAtZoomLoaded = false;
+        while (iter.hasNext()) {
+            OmeZarrBlockTileKey tileKey = (OmeZarrBlockTileKey) iter.next();
+
+            // look at finishedTile and remove tiles at different zoom level that are overlapping finishedTile
+            float distance = tileKey.getCentroid().distance(currFocus);
+            if (tileKey.getKeyDepth() != zoomLevel) {
+                obsoleteTiles.put(tileKey, currentTiles.get(tileKey));
+            } else {
+                blockAtZoomLoaded = true;
+                if (!desiredTiles.containsKey(tileKey))
+                    sortedCurrZoomTiles.put(distance, tileKey);
+            }
+        }
+        int i = 0;
+        Iterator<Float> tileIter = sortedCurrZoomTiles.keySet().iterator();
+        while (tileIter.hasNext()) {
+            BlockTileKey tileKey = sortedCurrZoomTiles.get(tileIter.next());
+            if (i > MAX_SIMULTANEOUS_BLOCKS) {
+                obsoleteTiles.put(tileKey, currentTiles.get(tileKey));
+            }
+            i++;
+        }
+
+        if (!blockAtZoomLoaded) {
+            obsoleteTiles.clear();
+        }
+
+        return obsoleteTiles;
+    }
+
+    private void initBlockSizes(OmeZarrBlockTileSource source) {
+        ArrayList<OmeZarrBlockResolution> resolutions = source.getResolutions();
+
+        resolutions.forEach(resolution -> {
+            ConstVector3 blockSize = source.getBlockSize(resolution);
+            LOG.info("block size [{}, {}, {}] for resolution {}", blockSize.getX(), blockSize.getY(), blockSize.getZ(), resolution);
+            float blockHeight = blockSize.getY();
+            zoomLevels.add((float) (blockHeight * BLOCK_WIDTH_ACROSS_VIEWPORT));
+            ///LOG.info("ZOOM LEVEL {} is {}", resolution.getResolution(), (float) (blockHeight * BLOCK_WIDTH_ACROSS_VIEWPORT));
+        });
+    }
+
+    // Sort blocks by distance from focus to block centroid
+    private static class BlockComparator<K extends BlockTileKey> implements Comparator<K> {
+
+        private final ConstVector3 focus;
+
+        BlockComparator(ConstVector3 focus) {
+            this.focus = focus;
+        }
+
+        @Override
+        public int compare(K block1, K block2) {
+            ConstVector3 c1 = block1.getCentroid().minus(focus);
+            ConstVector3 c2 = block2.getCentroid().minus(focus);
+            float d1 = c1.dot(c1); // distance squared
+            float d2 = c2.dot(c2);
+            return d1 < d2 ? -1 : d1 > d2 ? 1 : 0;
+        }
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockInfoSet.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockInfoSet.java
@@ -1,0 +1,121 @@
+package org.janelia.horta.blocks;
+
+import edu.wlu.cs.levy.CG.KDTree;
+import edu.wlu.cs.levy.CG.KeyDuplicateException;
+import edu.wlu.cs.levy.CG.KeySizeException;
+import org.janelia.geometry3d.ConstVector3;
+import org.openide.util.Exceptions;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+public class OmeZarrBlockInfoSet implements Set<OmeZarrBlockTileKey> {
+
+    // TODO - maybe just use the KDTree and not the HashSet?
+    private final Set<OmeZarrBlockTileKey> set = new HashSet<>();
+    private final KDTree<OmeZarrBlockTileKey> centroidIndex = new KDTree<>(3);
+
+    public OmeZarrBlockTileKey getBestContainingBrick(ConstVector3 xyz) {
+        double[] key = new double[] {xyz.getX(), xyz.getY(), xyz.getZ()};
+        try {
+            return centroidIndex.nearest(key);
+        } catch (KeySizeException | ArrayIndexOutOfBoundsException ex) {
+            Exceptions.printStackTrace(ex);
+            return null;
+        }
+    }
+
+    public Collection<OmeZarrBlockTileKey> getClosestBricks(float[] xyz, int count) {
+        double[] key = new double[] {xyz[0], xyz[1], xyz[2]};
+        try {
+            return centroidIndex.nearest(key, count);
+        } catch (KeySizeException ex) {
+            Exceptions.printStackTrace(ex);
+        } catch (IllegalArgumentException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+        return null;
+    }
+
+
+    @Override
+    public int size() {
+        return centroidIndex.size();
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return centroidIndex.size() == 0;
+    }
+
+    @Override
+    public boolean contains(Object o) {
+        return set.contains(o);
+    }
+
+    @Override
+    public Iterator<OmeZarrBlockTileKey> iterator() {
+        return set.iterator();
+    }
+
+    @Override
+    public Object[] toArray() {
+        return set.toArray();
+    }
+
+    @Override
+    public <T> T[] toArray(T[] a) {
+        return set.toArray(a);
+    }
+
+    @Override
+    public boolean add(OmeZarrBlockTileKey brickInfo) {
+        boolean result = set.add(brickInfo);
+
+        // Insert into KDTree for quick search
+        // TODO - update tree for all other inserting/deleting operations
+        ConstVector3 cv = brickInfo.getCentroid();
+        double[] ca = new double[] {cv.getX(), cv.getY(), cv.getZ()};
+        try {
+            centroidIndex.insert(ca, brickInfo);
+        } catch (KeySizeException ex) {
+            Exceptions.printStackTrace(ex);
+        } catch (KeyDuplicateException ex) {
+            Exceptions.printStackTrace(ex);
+        }
+
+        return result;
+    }
+
+    @Override
+    public boolean remove(Object o) {
+        return set.remove(o);
+    }
+
+    @Override
+    public boolean containsAll(Collection<?> c) {
+        return set.containsAll(c);
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends OmeZarrBlockTileKey> c) {
+        return set.addAll(c);
+    }
+
+    @Override
+    public boolean retainAll(Collection<?> c) {
+        return set.retainAll(c);
+    }
+
+    @Override
+    public boolean removeAll(Collection<?> c) {
+        return set.removeAll(c);
+    }
+
+    @Override
+    public void clear() {
+        set.clear();
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockLoadRunner.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockLoadRunner.java
@@ -1,0 +1,62 @@
+package org.janelia.horta.blocks;
+
+import org.janelia.geometry3d.ComposableObservable;
+import org.janelia.horta.actors.OmeZarrVolumeActor;
+import org.janelia.horta.actors.OmeZarrVolumeMeshActor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+public class OmeZarrBlockLoadRunner extends ComposableObservable implements Runnable {
+    private static final Logger LOG = LoggerFactory.getLogger(OmeZarrBlockLoadRunner.class);
+
+    public enum State {
+        INITIAL,
+        LOADING,
+        INTERRUPTED,
+        LOADED,
+        FAILED,
+    }
+
+    private OmeZarrBlockTileSource omeZarrBlockTileSource;
+    private OmeZarrBlockTileKey omeZarrOctreeBlockTileKey;
+
+    public OmeZarrBlockLoadRunner.State state = OmeZarrBlockLoadRunner.State.INITIAL;
+
+    public OmeZarrVolumeMeshActor blockActor;
+
+    public OmeZarrBlockLoadRunner(OmeZarrBlockTileSource source, OmeZarrBlockTileKey key) {
+        this.omeZarrBlockTileSource = source;
+        this.omeZarrOctreeBlockTileKey = key;
+    }
+
+    @Override
+    public void run() {
+        loadFromBlockSource();
+    }
+
+    private void loadFromBlockSource() {
+        long startTime = System.currentTimeMillis();
+        LOG.debug("Load OmeZarr tile {}", omeZarrOctreeBlockTileKey);
+        try {
+            state = OmeZarrBlockLoadRunner.State.LOADING;
+            OmeZarrVolumeActor parentActor = OmeZarrVolumeActor.getInstance();
+            blockActor = new OmeZarrVolumeMeshActor(omeZarrBlockTileSource, omeZarrOctreeBlockTileKey, parentActor.getVolumeState(), 0);
+            state = OmeZarrBlockLoadRunner.State.LOADED;
+            setChanged();
+            long endTime = System.currentTimeMillis();
+            LOG.info("Loading OmeZarr tile {} took {} ms", omeZarrOctreeBlockTileKey, endTime - startTime);
+            // notify listeners
+            notifyObservers();
+        } catch (IllegalStateException ex) {
+            // these are 404 errors for files which are missing (possibly correctly, our octree
+            //  isn't 100% complete) on disk
+            LOG.warn("IllegalStateException loading OmeZarr tile {} from block source", omeZarrOctreeBlockTileKey, ex);
+            state = OmeZarrBlockLoadRunner.State.FAILED;
+        } catch (IOException ex) {
+            LOG.warn("Exception loading OmeZarr tile {} from block source", omeZarrOctreeBlockTileKey, ex);
+            state = OmeZarrBlockLoadRunner.State.FAILED;
+        }
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockResolution.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockResolution.java
@@ -1,0 +1,79 @@
+package org.janelia.horta.blocks;
+
+public class OmeZarrBlockResolution implements BlockTileResolution {
+    private final int depth;
+
+    private final int[] chunkSizeXYZ;
+
+    private final double resolutionMicrometers;
+
+    private final int blockPowerScale;
+
+    private OmeZarrBlockInfoSet blockInfoSet = new OmeZarrBlockInfoSet();
+
+    public OmeZarrBlockResolution(int depth, int[] chunkSizeXYZ, double resolutionMicrometers, int blockPowerScale) {
+        this.depth = depth;
+        this.chunkSizeXYZ = chunkSizeXYZ;
+        this.resolutionMicrometers = resolutionMicrometers;
+        this.blockPowerScale = blockPowerScale;
+    }
+
+    @Override
+    public int getResolution() {
+        return depth;
+    }
+
+    public double getResolutionMicrometers() {
+        return resolutionMicrometers;
+    }
+
+    public double getBlockPowerScale() {
+        return blockPowerScale;
+    }
+
+    public OmeZarrBlockInfoSet getBlockInfoSet() {
+        return blockInfoSet;
+    }
+
+    public float getBlockSizeScale() {
+        return (float) Math.pow(2.5, getBlockPowerScale());
+    }
+
+    public int[] getChunkSize() {
+        float scale = getBlockSizeScale();
+
+        // return new int[]{(int) (shape[4] / scale), (int) (shape[3] / scale), (int) (shape[2] / scale)};
+        return chunkSizeXYZ;
+    }
+
+    @Override
+    public int hashCode() {
+        return depth;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final OmeZarrBlockResolution other = (OmeZarrBlockResolution) obj;
+        if (this.depth != other.depth) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int compareTo(BlockTileResolution o) {
+        OmeZarrBlockResolution rhs = (OmeZarrBlockResolution) o;
+        return depth < rhs.depth ? -1 : depth > rhs.depth ? 1 : 0;
+    }
+
+    @Override
+    public String toString() {
+        return String.format("depth: %d; um/voxel: %.1f; scaleFactor: %d", depth, resolutionMicrometers, blockPowerScale);
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockTileKey.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockTileKey.java
@@ -1,0 +1,191 @@
+package org.janelia.horta.blocks;
+
+import Jama.Matrix;
+import org.aind.omezarr.OmeZarrDataset;
+import org.aind.omezarr.image.AutoContrastParameters;
+import org.aind.omezarr.image.TCZYXRasterZStack;
+import org.janelia.geometry3d.ConstVector3;
+import org.janelia.geometry3d.Vector3;
+import org.janelia.gltools.texture.Texture3d;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.awt.*;
+import java.awt.color.ColorSpace;
+import java.awt.image.ColorModel;
+import java.awt.image.ComponentColorModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.WritableRaster;
+import java.util.ArrayList;
+import java.util.List;
+
+public class OmeZarrBlockTileKey implements BlockTileKey {
+    private static final Logger log = LoggerFactory.getLogger(OmeZarrBlockTileKey.class);
+
+    private OmeZarrDataset dataset;
+
+    private final int[] readShape;
+
+    private final int[] readOffset;
+
+    private final double[] voxelSize;
+
+    private final double[] shapeMicrometers;
+
+    private final double[] originMicrometers;
+
+    private final int[] pixelDims;
+
+    private final Vector3 blockOrigin;
+
+    private final Vector3 blockExtents;
+
+    private final int keyDepth;
+
+    private Matrix transform;
+
+    private Matrix stageCoordToTexCoord;
+
+    private List<ConstVector3> cornerLocations;
+
+    private final String relativePath;
+
+    public OmeZarrBlockTileKey(OmeZarrDataset dataset, int keyDepth, int[] shape, int[] offset, double[] voxelSize, int channelCount) {
+        this.dataset = dataset;
+
+        this.keyDepth = keyDepth;
+
+        this.voxelSize = voxelSize;
+
+        // TODO include any translate from multiscale/dataset coordinate transforms.
+        originMicrometers = new double[3];
+        shapeMicrometers = new double[3];
+        pixelDims = new int[4];
+
+        pixelDims[0] = shape[0];
+        pixelDims[1] = shape[1];
+        pixelDims[2] = shape[2];
+
+        originMicrometers[0] = this.voxelSize[0] * offset[0];
+        originMicrometers[1] = this.voxelSize[1] * offset[1];
+        originMicrometers[2] = this.voxelSize[2] * offset[2];
+
+        shapeMicrometers[0] = this.voxelSize[0] * pixelDims[0];
+        shapeMicrometers[1] = this.voxelSize[1] * pixelDims[1];
+        shapeMicrometers[2] = this.voxelSize[2] * pixelDims[2];
+
+        transform = new Matrix(
+                new double[][] {
+                        {shapeMicrometers[0]/pixelDims[0], 0, 0, originMicrometers[0]},
+                        {0, shapeMicrometers[1]/pixelDims[1], 0, originMicrometers[1]},
+                        {0, 0, shapeMicrometers[2]/pixelDims[2], originMicrometers[2]},
+                        {0, 0, 0, 1}
+                }
+        );
+
+        pixelDims[3] = channelCount;
+
+        // switch to [z, y, x] for jomezarr
+        this.readShape = new int[]{1, 1, shape[2], shape[1], shape[0]};
+
+        // switch to [z, y, x] for jomezarr
+        // Assumes tczyx dataset.  Default to time 0, channel 0.
+        this.readOffset = new int[]{0, 0, offset[2], offset[1], offset[0]};
+
+        blockOrigin = new Vector3(originMicrometers[0], originMicrometers[1], originMicrometers[2]);
+
+        blockExtents = new Vector3(shapeMicrometers[0], shapeMicrometers[1], shapeMicrometers[2]);
+
+        this.relativePath = String.format("[%s] [%.0f, %.0f, %.0f] [%.0f, %.0f, %.0f]", dataset.getPath(), originMicrometers[0], originMicrometers[1], originMicrometers[2], shapeMicrometers[0], shapeMicrometers[1], shapeMicrometers[2]);
+    }
+
+    @Override
+    public ConstVector3 getCentroid() { // Micrometers?
+        return blockExtents.multiplyScalar(0.5f).plus(blockOrigin);
+    }
+
+    public List<? extends ConstVector3> getCornerLocations() {
+        if (cornerLocations == null) {
+            cornerLocations = new ArrayList<>();
+            for (double pz : new double[]{0, pixelDims[2]}) {
+                for (double py : new double[]{0, pixelDims[1]}) {
+                    for (double px : new double[]{0, pixelDims[0]}) {
+                        Matrix corner = new Matrix(new double[]{(px + readOffset[4]) * voxelSize[0], (py + readOffset[3]) * voxelSize[1], (pz + readOffset[2]) * voxelSize[2], 1}, 4);
+                        ConstVector3 v = new Vector3(
+                                (float) corner.get(0, 0),
+                                (float) corner.get(1, 0),
+                                (float) corner.get(2, 0));
+                        cornerLocations.add(v);
+                    }
+                }
+            }
+        }
+
+        return cornerLocations;
+    }
+
+    public Matrix getStageCoordToTexCoord() {
+        // Compute matrix just-in-time
+        if (stageCoordToTexCoord == null) {
+/*
+            // For ray casting, convert from stageUm to texture coordinates (i.e. normalized voxels)
+            stageCoordToTexCoord = new Matrix(new double[][]{
+                    {1.0 / shapeMicrometers[0], 0, 0, 0},
+                    {0, 1.0 / shapeMicrometers[1], 0, 0},
+                    {0, 0, 1.0 / shapeMicrometers[2], 0},
+                    {0, 0, 0, 1}});
+
+ */
+            Matrix stageToVoxel = transform.inverse();
+
+           Matrix nanosToPixel = new Matrix(new double[][] {
+                    {1.0/pixelDims[0], 0, 0, 0},
+                    {0, 1.0/pixelDims[1], 0, 0},
+                    {0, 0, 1.0/pixelDims[2], 0},
+                    {0, 0, 0, 1}});
+
+            stageCoordToTexCoord = nanosToPixel.times(stageToVoxel);
+        }
+
+        return stageCoordToTexCoord;
+    }
+
+    public double getResolutionMicrometers() {
+        double resolution = Float.MAX_VALUE;
+
+        for (int xyz = 0; xyz < 3; ++xyz) {
+            double res = shapeMicrometers[xyz] / (double) pixelDims[xyz];
+            if (res < resolution)
+                resolution = res;
+        }
+
+        return resolution;
+    }
+
+    private static final ColorModel colorModel = new ComponentColorModel(ColorSpace.getInstance(ColorSpace.CS_GRAY), false, true, Transparency.OPAQUE, DataBuffer.TYPE_USHORT);
+
+    public Texture3d loadBrick(AutoContrastParameters parameters) {
+        Texture3d texture = new Texture3d();
+
+        try {
+            WritableRaster[] slices = TCZYXRasterZStack.fromDataset(dataset, readShape, readOffset, 1, false, null, null);
+
+            texture.loadRasterSlices(slices, colorModel);
+
+            return texture;
+        } catch (Exception e) {
+            log.error(e.getMessage());
+        }
+
+        return null;
+    }
+
+    public int getKeyDepth() {
+        return keyDepth;
+    }
+
+    @Override
+    public String toString() {
+        return relativePath;
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockTileSource.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockTileSource.java
@@ -1,0 +1,273 @@
+package org.janelia.horta.blocks;
+
+import org.aind.omezarr.OmeZarrAxisUnit;
+import org.aind.omezarr.OmeZarrDataset;
+import org.aind.omezarr.OmeZarrGroup;
+import org.aind.omezarr.image.AutoContrastParameters;
+import org.aind.omezarr.image.TCZYXRasterZStack;
+import org.apache.commons.lang3.StringUtils;
+import org.janelia.geometry3d.ConstVector3;
+import org.janelia.geometry3d.Vector3;
+import org.janelia.gltools.texture.Texture3d;
+import org.janelia.horta.omezarr.JadeZarrStoreProvider;
+import org.janelia.horta.omezarr.OmeZarrJadeReader;
+import org.janelia.model.domain.enums.FileType;
+import org.janelia.model.domain.tiledMicroscope.TmSample;
+import org.janelia.workstation.controller.model.color.ImageColorModel;
+import org.janelia.workstation.core.api.FileMgr;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.URL;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+
+public class OmeZarrBlockTileSource implements BlockTileSource<OmeZarrBlockTileKey> {
+    private static final Logger log = LoggerFactory.getLogger(OmeZarrBlockTileSource.class);
+
+    private URL originatingSampleURL;
+    private String sampleOmeZarrTilesBaseDir;
+    private OmeZarrJadeReader reader;
+    private OmeZarrGroup omeZarrGroup;
+
+    private ConstVector3 origin;
+    private Vector3 outerCorner;
+
+    private AutoContrastParameters autoContrastParameters = null;
+
+    private ArrayList<OmeZarrBlockResolution> resolutions = new ArrayList();
+    private OmeZarrBlockResolution maximumResolution = null;
+
+    private ImageColorModel imageColorModel;
+
+    private static final double MAX_BLOCKING_RESOLUTION = 30.0;
+
+    public OmeZarrBlockTileSource() {
+    }
+
+    public OmeZarrBlockTileSource(URL originatingSampleURL, ImageColorModel imageColorModel) {
+        this.originatingSampleURL = originatingSampleURL;
+        this.imageColorModel = imageColorModel;
+    }
+
+    public OmeZarrBlockTileSource init(String localPath) throws IOException {
+        this.sampleOmeZarrTilesBaseDir = localPath;
+        this.reader = null;
+
+        omeZarrGroup = OmeZarrGroup.open(Paths.get(localPath));
+
+        init();
+
+        return this;
+    }
+
+    public OmeZarrBlockTileSource init(TmSample sample) throws IOException {
+        this.sampleOmeZarrTilesBaseDir = StringUtils.appendIfMissing(sample.getFiles().get(FileType.LargeVolumeZarr),"/");
+
+        this.reader = new OmeZarrJadeReader(FileMgr.getFileMgr().getStorageService(), this.sampleOmeZarrTilesBaseDir);
+
+        omeZarrGroup = OmeZarrGroup.open(new JadeZarrStoreProvider("", reader));
+
+        init();
+
+        return this;
+    }
+
+    private void init() {
+        int datasetCount = omeZarrGroup.getAttributes().getMultiscales()[0].getDatasets().size();
+
+        int maxBlockingResolutionIndex = Integer.MIN_VALUE;
+
+        boolean haveExtents = false;
+
+        for (int idx = datasetCount - 1; idx >= 0; idx--) {
+            try {
+                OmeZarrDataset dataset = omeZarrGroup.getAttributes().getMultiscales()[0].getDatasets().get(idx);
+
+                if (this.reader != null) {
+                    dataset.setExternalZarrStore(new JadeZarrStoreProvider(dataset.getPath(), reader));
+                }
+
+                if (!dataset.isValid()) {
+                    continue;
+                }
+
+                // z, y, x order
+                int[] shape = dataset.getRawShape();
+                int[] chunkSize = dataset.getRawChunks();
+                int[] chunkSizeXYZ = {chunkSize[4], chunkSize[3], chunkSize[2]};
+
+                double resolutionMicrometers = dataset.getMinSpatialResolution();
+
+                if (!haveExtents) {
+                    // z, y,x order
+                    List<Double> res = dataset.getSpatialResolution(OmeZarrAxisUnit.MICROMETER);
+
+                    // TODO Respect translate transforms in dataset.
+                    origin = new Vector3(0, 0, 0);
+                    outerCorner = new Vector3(shape[4] * res.get(2).doubleValue(), shape[3] * res.get(1).doubleValue(), shape[2] * res.get(0).doubleValue());
+
+                    haveExtents = true;
+                }
+
+                OmeZarrBlockResolution resolution = new OmeZarrBlockResolution(idx, chunkSizeXYZ, resolutionMicrometers, 0);
+
+                if (resolutionMicrometers < MAX_BLOCKING_RESOLUTION) {
+                    if (idx > maxBlockingResolutionIndex) {
+                        maxBlockingResolutionIndex = idx;
+                    }
+
+                    resolution = new OmeZarrBlockResolution(idx, chunkSizeXYZ, resolutionMicrometers, maxBlockingResolutionIndex - idx + 1);
+
+                    if (maxBlockingResolutionIndex == idx) {
+                        maximumResolution = resolution;
+                    }
+                }
+
+                createTileKeysForDataset(resolution, idx, dataset);
+
+                resolutions.add(resolution);
+
+                if (maximumResolution == null) {
+                    maximumResolution = resolutions.get(resolutions.size() - 1);
+                }
+
+            } catch (Exception ex) {
+                log.info("failed to initialize dataset at index " + idx);
+            }
+        }
+    }
+
+    @Override
+    public BlockTileResolution getMaximumResolution() {
+        return maximumResolution;
+    }
+
+    @Override
+    public OmeZarrBlockTileKey getBlockKeyAt(ConstVector3 focus, BlockTileResolution resolution) {
+        return ((OmeZarrBlockResolution) resolution).getBlockInfoSet().getBestContainingBrick(focus);
+    }
+
+    @Override
+    public ConstVector3 getBlockCentroid(BlockTileKey centerBlock) {
+        return centerBlock.getCentroid();
+    }
+
+    @Override
+    public BlockTileData loadBlock(OmeZarrBlockTileKey key) {
+        return null;
+    }
+
+    @Override
+    public URL getOriginatingSampleURL() {
+        return this.originatingSampleURL;
+    }
+
+    public ImageColorModel getColorModel(){
+        return imageColorModel;
+    }
+
+    public ArrayList<OmeZarrBlockResolution> getResolutions() {
+        return resolutions;
+    }
+
+    ConstVector3 getBlockSize(OmeZarrBlockResolution resolution) {
+        Vector3 rootBlockSize = outerCorner.minus(origin);
+        return rootBlockSize.multiplyScalar(1.0f / resolution.getBlockSizeScale());
+    }
+
+    public Texture3d loadBrick(OmeZarrBlockTileKey tile, int colorChannel) {
+        // setColorChannelIndex(colorChannel);
+        return loadBrick(tile);
+    }
+
+    public Texture3d loadBrick(OmeZarrBlockTileKey tile) {
+        return tile.loadBrick(autoContrastParameters);
+    }
+
+    private void createTileKeysForDataset(OmeZarrBlockResolution resolution, int keyDepth, OmeZarrDataset dataset)  {
+
+        log.info(String.format("creating tile key set for resolution: %.1f", resolution.getResolutionMicrometers()));
+
+        OmeZarrBlockInfoSet blockInfoSet = resolution.getBlockInfoSet();
+
+        int[] chunkSize = resolution.getChunkSize();
+
+        List<OmeZarrBlockTileKey> chunks = createTilesForResolution(dataset, keyDepth, chunkSize[0], chunkSize[1], chunkSize[2]);
+
+        for (OmeZarrBlockTileKey chunk : chunks) {
+            blockInfoSet.add(chunk);
+        }
+    }
+
+    /**
+     * Only valid for tczyx OmeZarr datasets.
+     *
+     * @param dataset
+     * @return
+     * @throws IOException
+     */
+    private List<OmeZarrBlockTileKey> createTilesForResolution(OmeZarrDataset dataset, int keyDepth, int xChunkSegment, int yChunkSegment, int zChunkSegment) {
+        List<OmeZarrBlockTileKey> brickInfoList = new ArrayList<>();
+
+        try {
+            // [t, c, z, y, x]
+            int[] shape = dataset.getRawShape();
+
+            if (autoContrastParameters == null) {
+                int[] autoContrastShape = {1, 1, 256, 256, 128};
+
+                AutoContrastParameters parameters = TCZYXRasterZStack.computeAutoContrast(dataset, autoContrastShape);
+
+                if (parameters != null) {
+                    double existingMax = parameters.min + (65535.0 / parameters.slope);
+
+                    double min = Math.max(100, parameters.min * 0.1);
+                    double max = Math.min(65535.0, Math.max(min + 100, existingMax * 4));
+                    double slope = 65535.0 / (max - min);
+
+                    autoContrastParameters = new AutoContrastParameters(min, slope);
+                }
+            }
+
+            // [z, y, x]
+            List<Double> spatialShape = dataset.getSpatialResolution(OmeZarrAxisUnit.MICROMETER);
+
+            log.info("chunkSegments for dataset path " + dataset.getPath() + ": " + xChunkSegment + "," + yChunkSegment + "," + zChunkSegment);
+
+            int chunkCount = 0;
+
+            // [x, y, z]
+            int[] chunkSize = new int[3];
+
+            for (int xIdx = 0; xIdx < shape[4]; xIdx += xChunkSegment) {
+                for (int yIdx = 0; yIdx < shape[3]; yIdx += yChunkSegment) {
+                    for (int zIdx = 0; zIdx < shape[2]; zIdx += zChunkSegment) {
+                        // [x, y, z]
+                        int[] offset = {xIdx, yIdx, zIdx};
+
+                        chunkSize[0] = Math.min(shape[4] - xIdx, xChunkSegment);
+                        chunkSize[1] = Math.min(shape[3] - yIdx, yChunkSegment);
+                        chunkSize[2] = Math.min(shape[2] - zIdx, zChunkSegment);
+
+                        // [x, y, z]
+                        double[] voxelSize = {spatialShape.get(2), spatialShape.get(1), spatialShape.get(0)};
+
+                        // All args [x, y, z]
+                        brickInfoList.add(new OmeZarrBlockTileKey(dataset, keyDepth, chunkSize, offset, voxelSize, shape[1]));
+
+                        chunkCount++;
+                    }
+                }
+            }
+
+            log.info(chunkCount + " chunks for dataset path " + dataset.getPath());
+        } catch (Exception ex) {
+            log.info(ex.getMessage());
+        }
+
+        return brickInfoList;
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrTileCache.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrTileCache.java
@@ -1,0 +1,46 @@
+package org.janelia.horta.blocks;
+
+import org.janelia.horta.actors.SortableBlockActor;
+
+import javax.media.opengl.GL3;
+import java.util.Collection;
+import java.util.Map;
+
+public class OmeZarrTileCache  extends BasicTileCache<OmeZarrBlockTileKey, SortableBlockActor> {
+    private OmeZarrBlockTileSource source;
+
+    public OmeZarrTileCache(OmeZarrBlockTileSource source) {
+        this.source = source;
+    }
+
+    public void setSource(OmeZarrBlockTileSource source) {
+        this.source = source;
+    }
+
+    @Override
+    LoadRunner<OmeZarrBlockTileKey, SortableBlockActor> getLoadRunner() {
+        return key -> {
+            final OmeZarrBlockLoadRunner loader = new OmeZarrBlockLoadRunner(source, key);
+            loader.run();
+            return loader.blockActor;
+        };
+    }
+
+    public void disposeObsoleteTiles(GL3 gl) {
+        Collection<SortableBlockActor> obs = popObsoleteTiles();
+        for (SortableBlockActor actor : obs) {
+            actor.dispose(gl);
+        }
+    }
+
+    public void disposeGL(GL3 gl) {
+        disposeActorGroup(gl, nearVolumeInRam);
+    }
+
+    private void disposeActorGroup(GL3 gl, Map<OmeZarrBlockTileKey, SortableBlockActor> group) {
+        for (SortableBlockActor actor : group.values()) {
+            actor.dispose(gl);
+        }
+        group.clear();
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/controller/HortaManager.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/controller/HortaManager.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import java.util.List;
 
 import org.janelia.gltools.MeshActor;
+import org.janelia.horta.actors.OmeZarrVolumeActor;
 import org.janelia.horta.actors.TetVolumeActor;
 import org.janelia.model.domain.tiledMicroscope.TmObjectMesh;
 import org.janelia.workstation.controller.model.annotations.neuron.VertexCollectionWithNeuron;
@@ -139,6 +140,7 @@ public class HortaManager {
         try {
             renderer.clearNeuronReconstructions();
             TetVolumeActor.getInstance().clearAllBlocks();
+            OmeZarrVolumeActor.getInstance().clearAllBlocks();
             List<MeshActor> meshActorList = renderer.getMeshActors();
             for (MeshActor meshActor: meshActorList) {
                 renderer.removeMeshActor(meshActor);

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/loader/ObjMeshLoader.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/loader/ObjMeshLoader.java
@@ -44,8 +44,10 @@ public class ObjMeshLoader implements FileTypeLoader
     public void saveObjectMesh (String meshName, String filename) {
         TmObjectMesh newObjMesh = new TmObjectMesh(meshName, filename);
         try {
-            TmModelManager.getInstance().getCurrentWorkspace().addObjectMesh(newObjMesh);
-            TmModelManager.getInstance().saveCurrentWorkspace();
+            if(TmModelManager.getInstance().getCurrentWorkspace() != null) {
+                TmModelManager.getInstance().getCurrentWorkspace().addObjectMesh(newObjMesh);
+                TmModelManager.getInstance().saveCurrentWorkspace();
+            }
 
             // fire off event for scene editor
             MeshCreateEvent meshEvent = new MeshCreateEvent(this,

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/loader/OmeZarrLoader.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/loader/OmeZarrLoader.java
@@ -1,0 +1,34 @@
+package org.janelia.horta.loader;
+
+import org.apache.commons.io.FilenameUtils;
+import org.janelia.horta.NeuronTracerTopComponent;
+import org.janelia.horta.volume.StaticVolumeBrickSource;
+
+import java.io.IOException;
+
+/**
+ * For drag and drop.  Simply passes on the folder for input to OmeZarrVolumeBrickSource.
+ */
+public class OmeZarrLoader implements FileTypeLoader {
+    private final NeuronTracerTopComponent neuronTracerTopComponent;
+
+    public OmeZarrLoader(NeuronTracerTopComponent neuronTracerTopComponent) {
+        this.neuronTracerTopComponent = neuronTracerTopComponent;
+    }
+
+    @Override
+    public boolean supports(DataSource source)
+    {
+        return FilenameUtils.getExtension(source.getFileName()).equalsIgnoreCase("zarr");
+    }
+
+    @Override
+    public boolean load(final DataSource source, FileHandler handler) throws IOException
+    {
+        if (source instanceof FileDataSource) {
+            return neuronTracerTopComponent.loadDroppedOmeZarr(((FileDataSource)source).getFile().getAbsolutePath());
+        }
+
+        return false;
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/omezarr/JadeZarrStoreProvider.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/omezarr/JadeZarrStoreProvider.java
@@ -1,0 +1,57 @@
+package org.janelia.horta.omezarr;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.TreeSet;
+import java.util.stream.Stream;
+
+import org.aind.omezarr.zarr.ExternalZarrStore;
+
+public class JadeZarrStoreProvider extends ExternalZarrStore {
+
+    private final OmeZarrJadeReader reader;
+
+    public JadeZarrStoreProvider(String prefix, OmeZarrJadeReader reader)
+    {
+        super(prefix);
+
+        this.reader = reader;
+    }
+
+    @Override
+    public InputStream getInputStream(String s) throws IOException {
+        return reader.getInputStream(prefix.length() > 0 ? prefix + File.separator + s  :s);
+    }
+
+    @Override
+    public OutputStream getOutputStream(String s) throws IOException {
+        return null;
+    }
+
+    @Override
+    public void delete(String s) throws IOException {
+
+    }
+
+    @Override
+    public TreeSet<String> getArrayKeys() throws IOException {
+        return null;
+    }
+
+    @Override
+    public TreeSet<String> getGroupKeys() throws IOException {
+        return null;
+    }
+
+    @Override
+    public TreeSet<String> getKeysEndingWith(String s) throws IOException {
+        return null;
+    }
+
+    @Override
+    public Stream<String> getRelativeLeafKeys(String s) throws IOException {
+        return null;
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/omezarr/OmeZarrJadeReader.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/omezarr/OmeZarrJadeReader.java
@@ -1,0 +1,67 @@
+package org.janelia.horta.omezarr;
+
+import org.janelia.jacsstorage.clients.api.JadeStorageService;
+import org.janelia.jacsstorage.clients.api.StorageLocation;
+import org.janelia.jacsstorage.clients.api.StorageObject;
+import org.janelia.jacsstorage.clients.api.StorageObjectNotFoundException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.stream.Stream;
+
+public class OmeZarrJadeReader {
+    private final static Logger log = LoggerFactory.getLogger(OmeZarrJadeReader.class);
+
+    protected static final String attributesFile = ".zattrs";
+
+    protected final JadeStorageService jadeStorage;
+
+    protected final StorageLocation storageLocation;
+
+    protected final String basePath;
+
+    public OmeZarrJadeReader(final JadeStorageService jadeStorage, final String basePath) throws IOException {
+        this.jadeStorage = jadeStorage;
+        this.basePath = basePath;
+        this.storageLocation = jadeStorage.getStorageLocationByPath(basePath);
+
+        if (storageLocation == null) {
+            throw new IOException("Could not find Jade location for path: " + basePath);
+        }
+    }
+
+    public String getBasePath() {
+        return this.basePath;
+    }
+
+    public InputStream getInputStream(String location) {
+        final Path path = Paths.get(basePath, location);
+        String relativePath = storageLocation.getRelativePath(path.toString().replace("\\", "/"));
+        return jadeStorage.getContent(storageLocation, relativePath);
+    }
+
+    public InputStream getAttributesStream() {
+        final Path path = Paths.get(basePath, attributesFile);
+        String relativePath = storageLocation.getRelativePath(path.toString().replace("\\", "/"));
+        return jadeStorage.getContent(storageLocation, relativePath);
+    }
+
+    public String[] list(final String pathName) throws IOException {
+        log.trace("list " + pathName);
+        final Path path = Paths.get(basePath, pathName);
+        String relativePath = storageLocation.getRelativePath(path.toString());
+
+        try (Stream<StorageObject> stream = jadeStorage.getChildren(storageLocation, relativePath).stream()) {
+            return stream
+                    .filter(a -> a.isCollection())
+                    .map(a -> path.relativize(Paths.get(a.getAbsolutePath())).toString())
+                    .toArray(n -> new String[n]);
+        } catch (StorageObjectNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/modules/ViewerController/src/main/java/org/janelia/workstation/controller/dialog/NewTiledMicroscopeSampleDialog.java
+++ b/modules/ViewerController/src/main/java/org/janelia/workstation/controller/dialog/NewTiledMicroscopeSampleDialog.java
@@ -3,8 +3,6 @@ package org.janelia.workstation.controller.dialog;
 import java.awt.BorderLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
-import java.awt.event.ActionEvent;
-import java.awt.event.ActionListener;
 import java.awt.event.ItemEvent;
 import java.awt.event.ItemListener;
 import java.io.File;
@@ -15,29 +13,29 @@ import javax.swing.*;
 import org.apache.commons.lang.StringUtils;
 import org.janelia.model.domain.enums.FileType;
 import org.janelia.model.domain.tiledMicroscope.TmSample;
-import org.janelia.model.domain.tiledMicroscope.TmWorkspace;
 import org.janelia.workstation.common.gui.dialogs.ModalDialog;
 import org.janelia.workstation.controller.action.SaveTiledMicroscopeSampleAction;
-import org.janelia.workstation.controller.model.TmModelManager;
 import org.janelia.workstation.integration.util.FrameworkAccess;
 import org.jdesktop.swingx.VerticalLayout;
 
 public class NewTiledMicroscopeSampleDialog extends ModalDialog {
 	
-	private JTextField nameTextField = new JTextField(40);
-	private JTextField pathToOctreeTextField = new JTextField(40);
-	private JTextField pathToKTXTextField = new JTextField(40);
-	private JTextField pathToAltFormatTextField = new JTextField(40);
-	private JCheckBox rawCompressedField = new JCheckBox();
-	private JComboBox sampleFormat = new JComboBox<>(new String[] {"KTX Sample", "Zarr Sample"});
+	private final JTextField nameTextField = new JTextField(40);
+	private final JTextField pathToOctreeTextField = new JTextField(40);
+	private final JTextField pathToKTXTextField = new JTextField(40);
+	private final JTextField pathToOmeZarrFormatTextField = new JTextField(40);
+	private final JCheckBox rawCompressedField = new JCheckBox();
+	private final JComboBox<String> sampleFormat = new JComboBox<>(new String[] {ktxSample, zarrSample});
 
+	private static final String ktxSample = "KTX Sample";
+	private static final String zarrSample ="OME-Zarr Sample";
 
 	private TmSample sample;
 	GridBagConstraints c;
 	JPanel attrPanel;
 	JLabel pathToOctreeLabel = new JLabel("Path To Render Folder:");
 	JLabel pathToKTXLabel = new JLabel("Path To KTX Folder (optional):");
-	JLabel pathToAltFormatLabel = new JLabel("Path To Sample Top Folder:");
+	JLabel pathToOmeZarrFormatLabel = new JLabel("Path To OME-Zarr Fileset:");
 	JPanel mainPanel;
 
 	public NewTiledMicroscopeSampleDialog() {
@@ -66,6 +64,7 @@ public class NewTiledMicroscopeSampleDialog extends ModalDialog {
 		c.gridy = 1;
 		attrPanel.add(sampleFormatLabel, c);
 		c.gridx = 1;
+		c.anchor = GridBagConstraints.WEST;
 		attrPanel.add(sampleFormat, c);
 
 		// KTX Selections
@@ -80,11 +79,12 @@ public class NewTiledMicroscopeSampleDialog extends ModalDialog {
 		c.gridx = 1;
 		attrPanel.add(pathToKTXTextField, c);
 
+		// Zarr Selections
 		c.gridx = 0;
 		c.gridy = 4;
-		attrPanel.add(pathToAltFormatLabel, c);
+		attrPanel.add(pathToOmeZarrFormatLabel, c);
 		c.gridx = 1;
-		attrPanel.add(pathToAltFormatTextField, c);
+		attrPanel.add(pathToOmeZarrFormatTextField, c);
 
 		// Zarr selections
 		sampleFormat.addItemListener(new ItemListener() {
@@ -93,21 +93,21 @@ public class NewTiledMicroscopeSampleDialog extends ModalDialog {
 				if (itemEvent.getStateChange() == ItemEvent.SELECTED) {
 						String formatSelected = (String)itemEvent.getItem();
 						switch (formatSelected) {
-							case "KTX Sample":
+							case ktxSample:
 								pathToOctreeLabel.setVisible(true);
 								pathToOctreeTextField.setVisible(true);
 								pathToKTXLabel.setVisible(true);
 								pathToKTXTextField.setVisible(true);
-								pathToAltFormatLabel.setVisible(false);
-								pathToAltFormatTextField.setVisible(false);
+								pathToOmeZarrFormatLabel.setVisible(false);
+								pathToOmeZarrFormatTextField.setVisible(false);
 							    break;
-							case "Zarr Sample":
+							case zarrSample:
 								pathToOctreeLabel.setVisible(false);
 								pathToOctreeTextField.setVisible(false);
 								pathToKTXLabel.setVisible(false);
 								pathToKTXTextField.setVisible(false);
-								pathToAltFormatLabel.setVisible(true);
-								pathToAltFormatTextField.setVisible(true);
+								pathToOmeZarrFormatLabel.setVisible(true);
+								pathToOmeZarrFormatTextField.setVisible(true);
 
 								// Figure out the user path preference
 
@@ -165,7 +165,8 @@ public class NewTiledMicroscopeSampleDialog extends ModalDialog {
 		}
 
 		if (altPath!=null) {
-			pathToAltFormatTextField.setText(altPath);
+			pathToOmeZarrFormatTextField.setText(altPath);
+			sampleFormat.setSelectedItem(zarrSample);
 		}
 
 		packAndShow();
@@ -176,7 +177,7 @@ public class NewTiledMicroscopeSampleDialog extends ModalDialog {
 		String name = nameTextField.getText();
 		String octree = pathToOctreeTextField.getText();
 		String ktx = StringUtils.isBlank(pathToKTXTextField.getText()) ? null : pathToKTXTextField.getText();
-		String alt = StringUtils.isBlank(pathToAltFormatTextField.getText()) ? null : pathToAltFormatTextField.getText();
+		String alt = StringUtils.isBlank(pathToOmeZarrFormatTextField.getText()) ? null : pathToOmeZarrFormatTextField.getText();
 		if (octree.isEmpty()) {
 			JOptionPane.showMessageDialog(FrameworkAccess.getMainFrame(),
 					"You must specify both a sample name and location!",

--- a/modules/ViewerController/src/main/java/org/janelia/workstation/controller/tileimagery/SharedVolumeImage.java
+++ b/modules/ViewerController/src/main/java/org/janelia/workstation/controller/tileimagery/SharedVolumeImage.java
@@ -119,12 +119,20 @@ public class SharedVolumeImage implements VolumeImage3d {
         }
 
         loadAdapter = tileLoaderProvider.createLoadAdapter(volumeBaseURL.toString());
-        loadAdapter.loadMetadata();
 
-        // Update bounding box
-        // Compute bounding box
-        TileFormat tf = getLoadAdapter().getTileFormat();
-        BoundingBox3d newBox = tf.calcBoundingBox();
+        BoundingBox3d newBox;
+
+        try {
+            loadAdapter.loadMetadata();
+
+            // Update bounding box
+            // Compute bounding box
+            TileFormat tf = getLoadAdapter().getTileFormat();
+            newBox = tf.calcBoundingBox();
+        } catch (Exception ex) {
+            // Fails when sample is OmeZarr format.  Apply a default bounding box for now.
+            newBox = new BoundingBox3d(new Vec3(0, 0, 0), new Vec3(30000, 15000, 15000));
+        }
 
         boundingBox3d.setMin(newBox.getMin());
         boundingBox3d.setMax(newBox.getMax());

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 
         <janeliaws.jetty.version>9.4.46.v20220331</janeliaws.jetty.version>
 
-        <janeliaws.jacs-model.version>2.73.5</janeliaws.jacs-model.version>
+        <janeliaws.jacs-model.version>2.74.1</janeliaws.jacs-model.version>
 
         <janeliaws.jacs-messaging.version>2.5.0</janeliaws.jacs-messaging.version>
 


### PR DESCRIPTION
Preliminary support for OME-Zarr filesets.  Requires at least v2.74.1 of jacs model on the backend.

Primary HortaTracer module changes
- An OME-Zarr block-loading to rendering pipeline that is largely analogous to the existing KTX pipeline (all new files, no changes)
- Changes to NeuronTracerTopComponent and ViewLoader to choose between KTX and OME-Zarr tile sources and associated behaviors

Changes outside of HortaTracer module
- Add a method to Texture3d for Raster slices created or loaded elsewhere
- SharedVolumeImage workaround for metadata behavior w/OME-Zarr. Will be reverted and replaced in the future.
- Tiled Sample dialog/save/create method updates to allow for and accommodate the choice of a KTX or OME-Zarr fileset
- A couple of null checks that facilitated adding OME-Zarr as a supported drag and drop file type for easier dev and testing

Current known limitations
- Only supports OME-Zarr filesets w/unsigned short data types
- Only supports t, c, z, y, x filesets, not subsets, at this time
- Does not apply translation coordinate transforms in OmeZarr metadata, only scale transformations.
- Requires the blosc compression library be available on the machine (similar to N5 support I believe)
- jomezarr is publically available via GitHub, but GH requires authentication even for public artifacts.  It may or not be convenient to pull depending on your configuration.

Current known issues
- Tile clearing when opening a different sample is delayed.
- Bounding box for samples used for initial focus location and zoom level is not accurate
- When saving or editing an OME-Zarr sample it will say the sample path does not exist when it does.  Sample still works.
- Number of blocks loaded as a function of zoom level and zarr chunk size and which resolution to load as a function of zoom level requires additional work to not a) underload (not fill the view) at some zoom levels with smaller chunk sizes and b) overload non-visible chunks at some zoom levels