### PR TITLE
Update loading behavior for small Zarr chunk sizes in large samples

### DIFF
--- a/modules/HortaTracer/src/main/java/org/janelia/horta/actors/OmeZarrVolumeMeshActor.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/actors/OmeZarrVolumeMeshActor.java
@@ -45,7 +45,7 @@ public class OmeZarrVolumeMeshActor extends MeshActor implements SortableBlockAc
 
         this.homogeneousCentroid = new Vector4(centroid.getX(), centroid.getY(), centroid.getZ(), 1.0f);
 
-        resolution = new OmeZarrBlockResolution(tile.getKeyDepth(), tile.getShape(), tile.getResolutionMicrometers(), 0);
+        resolution = new OmeZarrBlockResolution(tile.getKeyDepth(), tile.getShape(), tile.getVoxelSize(), tile.getResolutionMicrometers());
 
         bbox_min = tile.getOrigin();
         Vector3 ext = tile.getExtents();

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/BasicTileCache.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/BasicTileCache.java
@@ -158,15 +158,15 @@ public abstract class BasicTileCache<TILE_KEY, TILE_DATA> {
                 synchronized (queuedTiles) {
                     RequestProcessor.Task task = queuedTiles.get(key);
                     if (task == null) {
-                        log.warn("Tile has no task: " + key.toString());
+                        log.warn("Tile has no task: " + getTileName(key));
                         return;
                     }
-                    log.info("Tile has loaded: {}",key.toString());
+                    log.info("Tile has loaded: {}", getTileName(key));
                     loadingTiles.put(key, task);
                     queuedTiles.remove(key);
                 }
 
-                ProgressHandle progress = ProgressHandleFactory.createHandle("Loading Tile " + key.toString() + " ...", null, null);
+                ProgressHandle progress = ProgressHandleFactory.createHandle("Loading Tile " + getTileName(key) + " ...", null, null);
 
                 try {
                     // Check whether this tile is still relevant
@@ -175,7 +175,7 @@ public abstract class BasicTileCache<TILE_KEY, TILE_DATA> {
                     }
 
                     progress.start();
-                    progress.setDisplayName("Loading Tile " + key.toString() + " ...");
+                    progress.setDisplayName("Loading Tile " + getTileName(key) + " ...");
                     progress.switchToIndeterminate();
 
                     log.debug("Tile cache load tile data for {}", key);
@@ -183,17 +183,17 @@ public abstract class BasicTileCache<TILE_KEY, TILE_DATA> {
                     TILE_DATA tileTexture = loadRunner.loadTile(key);
 
                     if (tileTexture == null) {
-                        log.info("Tile loaded was null {}", key.toString());
+                        log.info("Tile loaded was null {}", getTileName(key));
                         return;
                     }
 
                     if (!nearVolumeMetadata.contains(key)) {
-                        log.info("Tile loaded was no longer needed {}", key.toString());
+                        log.info("Tile loaded was no longer needed {}", getTileName(key));
                         return; // no longer needed
                     }
 
                     if (nearVolumeInRam.containsKey(key)) {
-                        log.info("Tile loaded was already loaded {}", key.toString());
+                        log.info("Tile loaded was already loaded {}", getTileName(key));
                         return; // already loaded by another thread?
                     }
 
@@ -201,9 +201,9 @@ public abstract class BasicTileCache<TILE_KEY, TILE_DATA> {
                     displayChangeObservable.setChanged();
                     displayChangeObservable.notifyObservers();
                 } catch (IOException ex) {
-                    log.info("loadTask was IOException {}", key.toString(), ex);
+                    log.info("loadTask was IOException {}", getTileName(key), ex);
                 } catch (InterruptedException ex) {
-                    log.info("loadTask was interrupted {}", key.toString(), ex);
+                    log.info("loadTask was interrupted {}", getTileName(key), ex);
                 } finally {
                     loadingTiles.remove(key);
                     // figure out if there are tiles we need to remove after successful load of a tile
@@ -220,7 +220,7 @@ public abstract class BasicTileCache<TILE_KEY, TILE_DATA> {
 
         // Submit load task asynchronously
         synchronized (queuedTiles) {
-            log.info("Queueing brick {} (queued={}, loading={})", key.toString(), queuedTiles.size(), loadingTiles.size());
+            log.info("Queueing brick {} (queued={}, loading={})", getTileName(key), queuedTiles.size(), loadingTiles.size());
             queuedTiles.put(key, loadProcessor.post(loadTask));
         }
         return true;
@@ -268,4 +268,7 @@ public abstract class BasicTileCache<TILE_KEY, TILE_DATA> {
         this.blockStrategy = blockStrategy;
     }
 
+    protected String getTileName(TILE_KEY key) {
+        return key.toString();
+    }
 }

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockChooser.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockChooser.java
@@ -22,7 +22,13 @@ public class OmeZarrBlockChooser implements BlockChooser<OmeZarrBlockTileKey, Om
     }
 
     public List<OmeZarrBlockTileKey> chooseBlocks(OmeZarrBlockTileSource source, ConstVector3 focus, Vantage vantage, int maxCount) {
-        if (zoomLevels.isEmpty()) {
+        List<OmeZarrBlockTileKey> result = new ArrayList<>();
+
+        if (source.getResolutions().size() == 0) {
+            return result;
+        }
+
+        if (zoomLevels.isEmpty() || zoomLevels.size() != source.getResolutions().size()) {
             initBlockSizes(source);
         }
 
@@ -84,8 +90,9 @@ public class OmeZarrBlockChooser implements BlockChooser<OmeZarrBlockTileKey, Om
         neighboringBlocks.sort(new BlockComparator<>(focus));
 
         // Return only the closest 8 blocks
-        List<OmeZarrBlockTileKey> result = new ArrayList<>();
+
         int listLen = Math.min(maxCount, neighboringBlocks.size());
+
         for (int i = 0; i < listLen; ++i) {
             result.add(neighboringBlocks.get(i));
         }
@@ -133,6 +140,8 @@ public class OmeZarrBlockChooser implements BlockChooser<OmeZarrBlockTileKey, Om
     }
 
     private void initBlockSizes(OmeZarrBlockTileSource source) {
+        zoomLevels.clear();
+
         ArrayList<OmeZarrBlockResolution> resolutions = source.getResolutions();
 
         resolutions.forEach(resolution -> {
@@ -140,7 +149,6 @@ public class OmeZarrBlockChooser implements BlockChooser<OmeZarrBlockTileKey, Om
             LOG.info("block size [{}, {}, {}] for resolution {}", blockSize.getX(), blockSize.getY(), blockSize.getZ(), resolution);
             float blockHeight = blockSize.getY();
             zoomLevels.add((float) (blockHeight * BLOCK_WIDTH_ACROSS_VIEWPORT));
-            ///LOG.info("ZOOM LEVEL {} is {}", resolution.getResolution(), (float) (blockHeight * BLOCK_WIDTH_ACROSS_VIEWPORT));
         });
     }
 

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockInfoSet.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockInfoSet.java
@@ -15,6 +15,14 @@ public class OmeZarrBlockInfoSet implements Set<OmeZarrBlockTileKey> {
     private final Set<OmeZarrBlockTileKey> set = new HashSet<>();
     private final KDTree<OmeZarrBlockTileKey> centroidIndex = new KDTree<>(3);
 
+    private final double[] voxelSize;
+
+    private final int[] chunkSize;
+
+    public OmeZarrBlockInfoSet(double[] voxelSize, int[] chunkSize) {
+        this.voxelSize = voxelSize;
+        this.chunkSize = chunkSize;
+    }
     public OmeZarrBlockTileKey getBestContainingBrick(ConstVector3 xyz, int maxCount) {
         double[] key = new double[]{xyz.getX(), xyz.getY(), xyz.getZ()};
 

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockInfoSet.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockInfoSet.java
@@ -1,8 +1,6 @@
 package org.janelia.horta.blocks;
 
 import edu.wlu.cs.levy.CG.KDTree;
-import edu.wlu.cs.levy.CG.KeyDuplicateException;
-import edu.wlu.cs.levy.CG.KeySizeException;
 import org.janelia.geometry3d.ConstVector3;
 import org.openide.util.Exceptions;
 
@@ -17,15 +15,16 @@ public class OmeZarrBlockInfoSet implements Set<OmeZarrBlockTileKey> {
     private final Set<OmeZarrBlockTileKey> set = new HashSet<>();
     private final KDTree<OmeZarrBlockTileKey> centroidIndex = new KDTree<>(3);
 
-    public OmeZarrBlockTileKey getBestContainingBrick(ConstVector3 xyz) {
+    public OmeZarrBlockTileKey getBestContainingBrick(ConstVector3 xyz, int maxCount) {
         double[] key = new double[]{xyz.getX(), xyz.getY(), xyz.getZ()};
 
         try {
             return centroidIndex.nearest(key);
-        } catch (KeySizeException | ArrayIndexOutOfBoundsException ex) {
+        } catch (Exception ex) {
             Exceptions.printStackTrace(ex);
-            return null;
         }
+
+        return null;
     }
 
     @Override
@@ -66,12 +65,21 @@ public class OmeZarrBlockInfoSet implements Set<OmeZarrBlockTileKey> {
         // TODO - update tree for all other inserting/deleting operations
         ConstVector3 cv = brickInfo.getCentroid();
 
-        double[] ca = new double[]{cv.getX(), cv.getY(), cv.getZ()};
-
         try {
+            double[] ca = new double[]{cv.getX(), cv.getY(), cv.getZ()};
             centroidIndex.insert(ca, brickInfo);
-        } catch (KeySizeException | KeyDuplicateException ex) {
-            Exceptions.printStackTrace(ex);
+        } catch (Exception ignored) {
+        }
+
+        return result;
+    }
+
+    @Override
+    public boolean addAll(Collection<? extends OmeZarrBlockTileKey> c) {
+        boolean result = false;
+
+        for (OmeZarrBlockTileKey chunk : c) {
+            result |= add(chunk);
         }
 
         return result;
@@ -85,17 +93,6 @@ public class OmeZarrBlockInfoSet implements Set<OmeZarrBlockTileKey> {
     @Override
     public boolean containsAll(Collection<?> c) {
         return set.containsAll(c);
-    }
-
-    @Override
-    public boolean addAll(Collection<? extends OmeZarrBlockTileKey> c) {
-        boolean result = false;
-
-        for (OmeZarrBlockTileKey chunk : c) {
-            result |= add(chunk);
-        }
-
-        return result;
     }
 
     @Override

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockLoadRunner.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockLoadRunner.java
@@ -19,8 +19,8 @@ public class OmeZarrBlockLoadRunner extends ComposableObservable implements Runn
         FAILED,
     }
 
-    private OmeZarrBlockTileSource omeZarrBlockTileSource;
-    private OmeZarrBlockTileKey omeZarrOctreeBlockTileKey;
+    private final OmeZarrBlockTileSource omeZarrBlockTileSource;
+    private final OmeZarrBlockTileKey omeZarrOctreeBlockTileKey;
 
     public OmeZarrBlockLoadRunner.State state = OmeZarrBlockLoadRunner.State.INITIAL;
 
@@ -46,16 +46,16 @@ public class OmeZarrBlockLoadRunner extends ComposableObservable implements Runn
             state = OmeZarrBlockLoadRunner.State.LOADED;
             setChanged();
             long endTime = System.currentTimeMillis();
-            LOG.info("Loading OmeZarr tile {} took {} ms", omeZarrOctreeBlockTileKey, endTime - startTime);
+            LOG.info("Loading Ome-Zarr tile {} took {} ms", omeZarrOctreeBlockTileKey.getRelativePath(), endTime - startTime);
             // notify listeners
             notifyObservers();
         } catch (IllegalStateException ex) {
             // these are 404 errors for files which are missing (possibly correctly, our octree
             //  isn't 100% complete) on disk
-            LOG.warn("IllegalStateException loading OmeZarr tile {} from block source", omeZarrOctreeBlockTileKey, ex);
+            LOG.warn("IllegalStateException loading Ome-Zarr tile {} from block source", omeZarrOctreeBlockTileKey.getRelativePath(), ex);
             state = OmeZarrBlockLoadRunner.State.FAILED;
         } catch (IOException ex) {
-            LOG.warn("Exception loading OmeZarr tile {} from block source", omeZarrOctreeBlockTileKey, ex);
+            LOG.warn("Exception loading Ome-Zarr tile {} from block source", omeZarrOctreeBlockTileKey.getRelativePath(), ex);
             state = OmeZarrBlockLoadRunner.State.FAILED;
         }
     }

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockResolution.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockResolution.java
@@ -9,7 +9,7 @@ public class OmeZarrBlockResolution implements BlockTileResolution {
 
     private final int blockPowerScale;
 
-    private OmeZarrBlockInfoSet blockInfoSet = new OmeZarrBlockInfoSet();
+    private final OmeZarrBlockInfoSet blockInfoSet = new OmeZarrBlockInfoSet();
 
     public OmeZarrBlockResolution(int depth, int[] chunkSizeXYZ, double resolutionMicrometers, int blockPowerScale) {
         this.depth = depth;
@@ -23,27 +23,8 @@ public class OmeZarrBlockResolution implements BlockTileResolution {
         return depth;
     }
 
-    public double getResolutionMicrometers() {
-        return resolutionMicrometers;
-    }
-
-    public double getBlockPowerScale() {
-        return blockPowerScale;
-    }
-
-    public OmeZarrBlockInfoSet getBlockInfoSet() {
-        return blockInfoSet;
-    }
-
-    public float getBlockSizeScale() {
-        return (float) Math.pow(2.5, getBlockPowerScale());
-    }
-
-    public int[] getChunkSize() {
-        float scale = getBlockSizeScale();
-
-        // return new int[]{(int) (shape[4] / scale), (int) (shape[3] / scale), (int) (shape[2] / scale)};
-        return chunkSizeXYZ;
+    public int getDepth() {
+        return depth;
     }
 
     @Override
@@ -69,11 +50,23 @@ public class OmeZarrBlockResolution implements BlockTileResolution {
     @Override
     public int compareTo(BlockTileResolution o) {
         OmeZarrBlockResolution rhs = (OmeZarrBlockResolution) o;
-        return depth < rhs.depth ? -1 : depth > rhs.depth ? 1 : 0;
+        return Integer.compare(depth, rhs.depth);
     }
 
     @Override
     public String toString() {
         return String.format("depth: %d; um/voxel: %.1f; scaleFactor: %d", depth, resolutionMicrometers, blockPowerScale);
+    }
+
+    public double getResolutionMicrometers() {
+        return resolutionMicrometers;
+    }
+
+    public OmeZarrBlockInfoSet getBlockInfoSet() {
+        return blockInfoSet;
+    }
+
+    public int[] getChunkSize() {
+        return chunkSizeXYZ;
     }
 }

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockResolution.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockResolution.java
@@ -7,15 +7,17 @@ public class OmeZarrBlockResolution implements BlockTileResolution {
 
     private final double resolutionMicrometers;
 
-    private final int blockPowerScale;
+    private final double[] voxelSize;
 
-    private final OmeZarrBlockInfoSet blockInfoSet = new OmeZarrBlockInfoSet();
+    private final OmeZarrBlockInfoSet blockInfoSet;
 
-    public OmeZarrBlockResolution(int depth, int[] chunkSizeXYZ, double resolutionMicrometers, int blockPowerScale) {
+    public OmeZarrBlockResolution(int depth, int[] chunkSizeXYZ, double[] voxelSize, double resolutionMicrometers) {
         this.depth = depth;
         this.chunkSizeXYZ = chunkSizeXYZ;
         this.resolutionMicrometers = resolutionMicrometers;
-        this.blockPowerScale = blockPowerScale;
+        this.voxelSize = voxelSize;
+
+        blockInfoSet = new OmeZarrBlockInfoSet(voxelSize, chunkSizeXYZ);
     }
 
     @Override
@@ -55,7 +57,7 @@ public class OmeZarrBlockResolution implements BlockTileResolution {
 
     @Override
     public String toString() {
-        return String.format("depth: %d; um/voxel: %.1f; scaleFactor: %d", depth, resolutionMicrometers, blockPowerScale);
+        return String.format("depth: %d; um/voxel: %.1f", depth, resolutionMicrometers);
     }
 
     public double getResolutionMicrometers() {

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockTileKey.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockTileKey.java
@@ -188,6 +188,14 @@ public class OmeZarrBlockTileKey implements BlockTileKey {
         return pixelDims;
     }
 
+    public double[] getVoxelSize(){
+        return voxelSize;
+    }
+
+    public int[] getReadOffset() {
+        return readOffset;
+    }
+
     public String getRelativePath() {
         if (relativePath == null) {
             relativePath = String.format("[%s] [%.0f, %.0f, %.0f] [%.0f, %.0f, %.0f]", dataset.getPath(), blockOrigin.getX(), blockOrigin.getY(), blockOrigin.getY(), shapeMicrometers[0], shapeMicrometers[1], shapeMicrometers[2]);

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockTileKey.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockTileKey.java
@@ -48,7 +48,7 @@ public class OmeZarrBlockTileKey implements BlockTileKey {
 
     private List<ConstVector3> cornerLocations;
 
-    private final String relativePath;
+    private String relativePath = null;
 
     public OmeZarrBlockTileKey(OmeZarrDataset dataset, int keyDepth, int[] shape, int[] offset, double[] voxelSize, int channelCount) {
         this.dataset = dataset;
@@ -97,8 +97,6 @@ public class OmeZarrBlockTileKey implements BlockTileKey {
         blockExtents = new Vector3(shapeMicrometers[0], shapeMicrometers[1], shapeMicrometers[2]);
 
         blockCentroid = new Vector3(blockExtents.get(0) * 0.5f + blockOrigin.get(0), blockExtents.get(1) * 0.5f + blockOrigin.get(1), blockExtents.get(2) * 0.5f + blockOrigin.get(2));
-
-        this.relativePath = String.format("[%s] [%.0f, %.0f, %.0f] [%.0f, %.0f, %.0f]", dataset.getPath(), originMicrometers[0], originMicrometers[1], originMicrometers[2], shapeMicrometers[0], shapeMicrometers[1], shapeMicrometers[2]);
     }
 
     @Override
@@ -190,8 +188,10 @@ public class OmeZarrBlockTileKey implements BlockTileKey {
         return pixelDims;
     }
 
-    @Override
-    public String toString() {
+    public String getRelativePath() {
+        if (relativePath == null) {
+            relativePath = String.format("[%s] [%.0f, %.0f, %.0f] [%.0f, %.0f, %.0f]", dataset.getPath(), blockOrigin.getX(), blockOrigin.getY(), blockOrigin.getY(), shapeMicrometers[0], shapeMicrometers[1], shapeMicrometers[2]);
+        }
         return relativePath;
     }
 }

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockTileSource.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockTileSource.java
@@ -11,6 +11,8 @@ import org.janelia.geometry3d.Vector3;
 import org.janelia.gltools.texture.Texture3d;
 import org.janelia.horta.omezarr.JadeZarrStoreProvider;
 import org.janelia.horta.omezarr.OmeZarrJadeReader;
+import org.janelia.horta.omezarr.OmeZarrReaderProgressObserver;
+import org.janelia.horta.omezarr.OmeZarrReaderCompletionObserver;
 import org.janelia.model.domain.enums.FileType;
 import org.janelia.model.domain.tiledMicroscope.TmSample;
 import org.janelia.workstation.controller.model.color.ImageColorModel;
@@ -25,6 +27,8 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class OmeZarrBlockTileSource implements BlockTileSource<OmeZarrBlockTileKey> {
     private static final Logger log = LoggerFactory.getLogger(OmeZarrBlockTileSource.class);
@@ -46,6 +50,8 @@ public class OmeZarrBlockTileSource implements BlockTileSource<OmeZarrBlockTileK
     private BoundingBox3d boundingBox3d = new BoundingBox3d();
     private Vec3 voxelCenter = new Vec3(0, 0, 0);
 
+    private static final ExecutorService cachedThreadPool = Executors.newCachedThreadPool();
+
     private static final double MAX_BLOCKING_RESOLUTION = 30.0;
 
     public OmeZarrBlockTileSource(URL originatingSampleURL, ImageColorModel imageColorModel) {
@@ -59,93 +65,105 @@ public class OmeZarrBlockTileSource implements BlockTileSource<OmeZarrBlockTileK
     }
 
     public OmeZarrBlockTileSource init(String localPath) throws IOException {
+        return init(localPath, null, null);
+    }
+
+    public OmeZarrBlockTileSource init(String localPath, OmeZarrReaderProgressObserver progressObserver, OmeZarrReaderCompletionObserver completionObserver) throws IOException {
         this.sampleOmeZarrTilesBaseDir = localPath;
+
         this.reader = null;
 
         omeZarrGroup = OmeZarrGroup.open(Paths.get(localPath));
 
-        init();
-
-        return this;
+        return init(progressObserver, completionObserver);
     }
 
     public OmeZarrBlockTileSource init(TmSample sample) throws IOException {
+        return init(sample, null, null);
+    }
+
+    public OmeZarrBlockTileSource init(TmSample sample, OmeZarrReaderProgressObserver progressObserver, OmeZarrReaderCompletionObserver completionObserver) throws IOException {
         this.sampleOmeZarrTilesBaseDir = StringUtils.appendIfMissing(sample.getFiles().get(FileType.LargeVolumeZarr), "/");
 
         this.reader = new OmeZarrJadeReader(FileMgr.getFileMgr().getStorageService(), this.sampleOmeZarrTilesBaseDir);
 
         omeZarrGroup = OmeZarrGroup.open(new JadeZarrStoreProvider("", reader));
 
-        init();
-
-        return this;
+        return init(progressObserver, completionObserver);
     }
 
-    private void init() {
-        int datasetCount = omeZarrGroup.getAttributes().getMultiscales()[0].getDatasets().size();
+    private OmeZarrBlockTileSource init(OmeZarrReaderProgressObserver progressObserver, OmeZarrReaderCompletionObserver completionObserver) {
+        cachedThreadPool.submit(() -> {
+            int datasetCount = omeZarrGroup.getAttributes().getMultiscales()[0].getDatasets().size();
 
-        int maxBlockingResolutionIndex = Integer.MIN_VALUE;
+            int maxBlockingResolutionIndex = Integer.MIN_VALUE;
 
-        boolean haveExtents = false;
+            boolean haveExtents = false;
 
-        for (int idx = datasetCount - 1; idx >= 0; idx--) {
-            try {
-                OmeZarrDataset dataset = omeZarrGroup.getAttributes().getMultiscales()[0].getDatasets().get(idx);
+            for (int idx = datasetCount - 1; idx >= 0; idx--) {
+                try {
+                    OmeZarrDataset dataset = omeZarrGroup.getAttributes().getMultiscales()[0].getDatasets().get(idx);
 
-                if (this.reader != null) {
-                    dataset.setExternalZarrStore(new JadeZarrStoreProvider(dataset.getPath(), reader));
-                }
-
-                if (!dataset.isValid()) {
-                    continue;
-                }
-
-                // z, y, x order
-                int[] shape = dataset.getRawShape();
-                int[] chunkSize = dataset.getRawChunks();
-                int[] chunkSizeXYZ = {chunkSize[4], chunkSize[3], chunkSize[2]};
-
-                double resolutionMicrometers = dataset.getMinSpatialResolution();
-
-                if (!haveExtents) {
-                    // z, y,x order
-                    List<Double> res = dataset.getSpatialResolution(OmeZarrAxisUnit.MICROMETER);
-
-                    // TODO Respect translate transforms in dataset.
-                    ConstVector3 origin = new Vector3(0, 0, 0);
-                    Vector3 outerCorner = new Vector3(shape[4] * res.get(2), shape[3] * res.get(1), shape[2] * res.get(0));
-                    boundingBox3d = new BoundingBox3d(new Vec3(origin.getX(), origin.getY(), origin.getX()), new Vec3(outerCorner.getX(), outerCorner.getY(), outerCorner.getX()));
-                    voxelCenter = boundingBox3d.getCenter();
-
-                    haveExtents = true;
-                }
-
-                OmeZarrBlockResolution resolution = new OmeZarrBlockResolution(idx, chunkSizeXYZ, resolutionMicrometers, 0);
-
-                if (resolutionMicrometers < MAX_BLOCKING_RESOLUTION) {
-                    if (idx > maxBlockingResolutionIndex) {
-                        maxBlockingResolutionIndex = idx;
+                    if (this.reader != null) {
+                        dataset.setExternalZarrStore(new JadeZarrStoreProvider(dataset.getPath(), reader));
                     }
 
-                    resolution = new OmeZarrBlockResolution(idx, chunkSizeXYZ, resolutionMicrometers, maxBlockingResolutionIndex - idx + 1);
-
-                    if (maxBlockingResolutionIndex == idx) {
-                        maximumResolution = resolution;
+                    if (!dataset.isValid()) {
+                        // Might be a dataset listed in .zattrs that is not available in the datastore.
+                        continue;
                     }
+
+                    // z, y, x order
+                    int[] shape = dataset.getRawShape();
+                    int[] chunkSize = dataset.getRawChunks();
+                    int[] chunkSizeXYZ = {chunkSize[4], chunkSize[3], chunkSize[2]};
+
+                    double resolutionMicrometers = dataset.getMinSpatialResolution();
+
+                    if (!haveExtents) {
+                        // z, y,x order
+                        List<Double> res = dataset.getSpatialResolution(OmeZarrAxisUnit.MICROMETER);
+
+                        // TODO Respect translate transforms in dataset.
+                        ConstVector3 origin = new Vector3(0, 0, 0);
+                        Vector3 outerCorner = new Vector3(shape[4] * res.get(2), shape[3] * res.get(1), shape[2] * res.get(0));
+                        boundingBox3d = new BoundingBox3d(new Vec3(origin.getX(), origin.getY(), origin.getX()), new Vec3(outerCorner.getX(), outerCorner.getY(), outerCorner.getX()));
+                        voxelCenter = boundingBox3d.getCenter();
+
+                        haveExtents = true;
+                    }
+
+                    OmeZarrBlockResolution resolution = new OmeZarrBlockResolution(idx, chunkSizeXYZ, resolutionMicrometers, 0);
+
+                    if (resolutionMicrometers < MAX_BLOCKING_RESOLUTION) {
+                        if (idx > maxBlockingResolutionIndex) {
+                            maxBlockingResolutionIndex = idx;
+                        }
+
+                        resolution = new OmeZarrBlockResolution(idx, chunkSizeXYZ, resolutionMicrometers, maxBlockingResolutionIndex - idx + 1);
+
+                        if (maxBlockingResolutionIndex == idx) {
+                            maximumResolution = resolution;
+                        }
+                    }
+
+                    createTileKeysForDataset(resolution, dataset, progressObserver);
+
+                    resolutions.add(resolution);
+
+                    if (maximumResolution == null) {
+                        maximumResolution = resolutions.get(resolutions.size() - 1);
+                    }
+
+                } catch (Exception ex) {
+                    log.info("failed to initialize dataset at index " + idx);
                 }
-
-                createTileKeysForDataset(resolution, idx, dataset);
-
-                resolutions.add(resolution);
-
-                if (maximumResolution == null) {
-                    maximumResolution = resolutions.get(resolutions.size() - 1);
-                }
-
-            } catch (Exception ex) {
-                log.info("failed to initialize dataset at index " + idx);
             }
-        }
+
+            completionObserver.complete(this);
+        });
+
+        return this;
     }
 
     public BoundingBox3d getBoundingBox3d() {
@@ -163,7 +181,11 @@ public class OmeZarrBlockTileSource implements BlockTileSource<OmeZarrBlockTileK
 
     @Override
     public OmeZarrBlockTileKey getBlockKeyAt(ConstVector3 focus, BlockTileResolution resolution) {
-        return ((OmeZarrBlockResolution) resolution).getBlockInfoSet().getBestContainingBrick(focus);
+        if (resolution == null) {
+            return null;
+        }
+
+        return ((OmeZarrBlockResolution) resolution).getBlockInfoSet().getBestContainingBrick(focus, 1);
     }
 
     @Override
@@ -190,9 +212,6 @@ public class OmeZarrBlockTileSource implements BlockTileSource<OmeZarrBlockTileK
     }
 
     ConstVector3 getBlockSize(OmeZarrBlockResolution resolution) {
-        // Vector3 rootBlockSize = outerCorner.minus(origin);
-        // return rootBlockSize.multiplyScalar(1.0f / resolution.getBlockSizeScale());
-
         return new Vector3(resolution.getChunkSize()[0] * resolution.getResolutionMicrometers(),
                 resolution.getChunkSize()[1] * resolution.getResolutionMicrometers(),
                 resolution.getChunkSize()[2] * resolution.getResolutionMicrometers());
@@ -207,85 +226,100 @@ public class OmeZarrBlockTileSource implements BlockTileSource<OmeZarrBlockTileK
         return tile.loadBrick(useAutoContrast ? autoContrastParameters : null);
     }
 
-    private void createTileKeysForDataset(OmeZarrBlockResolution resolution, int keyDepth, OmeZarrDataset dataset) {
-
-        log.info(String.format("creating tile key set for resolution: %.1f", resolution.getResolutionMicrometers()));
-
-        OmeZarrBlockInfoSet blockInfoSet = resolution.getBlockInfoSet();
-
-        int[] chunkSize = resolution.getChunkSize();
-
-        List<OmeZarrBlockTileKey> chunks = createTilesForResolution(dataset, keyDepth, chunkSize[0], chunkSize[1], chunkSize[2]);
-
-        blockInfoSet.addAll(chunks);
-    }
-
     /**
      * Only valid for tczyx OmeZarr datasets.
-     *
-     * @param dataset
-     * @return
-     * @throws IOException
      */
-    private List<OmeZarrBlockTileKey> createTilesForResolution(OmeZarrDataset dataset, int keyDepth, int xChunkSegment, int yChunkSegment, int zChunkSegment) {
-        List<OmeZarrBlockTileKey> brickInfoList = new ArrayList<>();
-
+    private void createTileKeysForDataset(OmeZarrBlockResolution resolution, OmeZarrDataset dataset, OmeZarrReaderProgressObserver progressReceiver) {
         try {
+            OmeZarrBlockInfoSet blockInfoSet = resolution.getBlockInfoSet();
+
+            // [x, y, z]
+            int[] chunkSize = resolution.getChunkSize();
+
+            int xChunkSegment = chunkSize[0];
+            int yChunkSegment = chunkSize[1];
+            int zChunkSegment = chunkSize[2];
+
             // [t, c, z, y, x]
             int[] shape = dataset.getRawShape();
-
-            if (autoContrastParameters == null) {
-                int[] autoContrastShape = {1, 1, 256, 256, 128};
-
-                AutoContrastParameters parameters = TCZYXRasterZStack.computeAutoContrast(dataset, autoContrastShape);
-
-                if (parameters != null) {
-                    double existingMax = parameters.min + (65535.0 / parameters.slope);
-
-                    double min = Math.max(100, parameters.min * 0.1);
-                    double max = Math.min(65535.0, Math.max(min + 100, existingMax * 4));
-                    double slope = 65535.0 / (max - min);
-
-                    autoContrastParameters = new AutoContrastParameters(min, slope);
-                }
-            }
 
             // [z, y, x]
             List<Double> spatialShape = dataset.getSpatialResolution(OmeZarrAxisUnit.MICROMETER);
 
-            log.info("chunkSegments for dataset path " + dataset.getPath() + ": " + xChunkSegment + "," + yChunkSegment + "," + zChunkSegment);
+            // [x, y, z]
+            double[] voxelSize = {spatialShape.get(2), spatialShape.get(1), spatialShape.get(0)};
 
-            int chunkCount = 0;
+            int chunkCount = (int) (Math.ceil(1.0 * shape[4] / xChunkSegment) * Math.ceil(1.0 * shape[3] / yChunkSegment) * Math.ceil(1.0 * shape[2] / zChunkSegment));
+
+            List<OmeZarrBlockTileKey> brickInfoList = new ArrayList<>(chunkCount);
+
+            if (progressReceiver != null) {
+                progressReceiver.update(this, "Loading dataset " + dataset.getPath() + " (" + chunkCount + " tiles remaining)");
+            }
+
+            log.info(String.format("preparing " + chunkCount + " tile keys for resolution: %.1fum/voxel (path " + dataset.getPath() + ", tile size: [" + xChunkSegment + "," + yChunkSegment + "," + zChunkSegment + "])", resolution.getResolutionMicrometers()));
+
+            if (useAutoContrast && autoContrastParameters == null) {
+                int[] autoContrastShape = {1, 1, 256, 256, 128};
+
+                AutoContrastParameters parameters = TCZYXRasterZStack.computeAutoContrast(dataset, autoContrastShape);
+
+                double existingMax = parameters.min + (65535.0 / parameters.slope);
+
+                double min = Math.max(100, parameters.min * 0.1);
+                double max = Math.min(65535.0, Math.max(min + 100, existingMax * 4));
+                double slope = 65535.0 / (max - min);
+
+                autoContrastParameters = new AutoContrastParameters(min, slope);
+            }
+
+            int keyDepth = resolution.getDepth();
 
             // [x, y, z]
-            int[] chunkSize = new int[3];
+            int[] actualChunkSize = new int[3];
+            int[] offset = new int[3];
 
             for (int xIdx = 0; xIdx < shape[4]; xIdx += xChunkSegment) {
                 for (int yIdx = 0; yIdx < shape[3]; yIdx += yChunkSegment) {
                     for (int zIdx = 0; zIdx < shape[2]; zIdx += zChunkSegment) {
                         // [x, y, z]
-                        int[] offset = {xIdx, yIdx, zIdx};
+                        offset[0] = xIdx;
+                        offset[1] = yIdx;
+                        offset[2] = zIdx;
 
-                        chunkSize[0] = Math.min(shape[4] - xIdx, xChunkSegment);
-                        chunkSize[1] = Math.min(shape[3] - yIdx, yChunkSegment);
-                        chunkSize[2] = Math.min(shape[2] - zIdx, zChunkSegment);
-
-                        // [x, y, z]
-                        double[] voxelSize = {spatialShape.get(2), spatialShape.get(1), spatialShape.get(0)};
+                        actualChunkSize[0] = Math.min(shape[4] - xIdx, xChunkSegment);
+                        actualChunkSize[1] = Math.min(shape[3] - yIdx, yChunkSegment);
+                        actualChunkSize[2] = Math.min(shape[2] - zIdx, zChunkSegment);
 
                         // All args [x, y, z]
-                        brickInfoList.add(new OmeZarrBlockTileKey(dataset, keyDepth, chunkSize, offset, voxelSize, shape[1]));
+                        brickInfoList.add(new OmeZarrBlockTileKey(dataset, keyDepth, actualChunkSize, offset, voxelSize, shape[1]));
 
-                        chunkCount++;
+                        chunkCount--;
+
+                        if (chunkCount % 250000 == 0) {
+                            if (progressReceiver != null) {
+                                progressReceiver.update(this,"Loading dataset " + dataset.getPath() + " (" + chunkCount + " tiles remaining)");
+                            }
+                        }
                     }
                 }
             }
 
-            log.info(chunkCount + " chunks for dataset path " + dataset.getPath());
-        } catch (Exception ex) {
-            log.info(ex.getMessage());
-        }
+            if (progressReceiver != null) {
+                progressReceiver.update(this, "Loading dataset " + dataset.getPath() + " (building spatial tree)");
+            }
 
-        return brickInfoList;
+            long startTime = System.currentTimeMillis();
+
+            blockInfoSet.addAll(brickInfoList);
+
+            long endTime = System.currentTimeMillis();
+            log.info("Spatial index build for path {} took {} ms", dataset.getPath(), endTime - startTime);
+
+            log.error("finished loading path " + dataset.getPath());
+        } catch (Exception ex) {
+            log.error("failed to load path " + dataset.getPath());
+            log.error(ex.getMessage());
+        }
     }
 }

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrOffsetKey.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrOffsetKey.java
@@ -1,0 +1,31 @@
+package org.janelia.horta.blocks;
+
+import java.util.Arrays;
+
+public class OmeZarrOffsetKey {
+
+    private final int[] readOffset;
+
+    public OmeZarrOffsetKey(int[] readOffset) {
+        this.readOffset = readOffset;
+    }
+
+    @Override
+    public int hashCode() {
+        int hash = 3;
+        return 53 * hash + Arrays.hashCode(this.readOffset);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (obj == null) {
+            return false;
+        }
+        if (getClass() != obj.getClass()) {
+            return false;
+        }
+        final OmeZarrOffsetKey other = (OmeZarrOffsetKey) obj;
+
+        return Arrays.equals(readOffset, other.readOffset);
+    }
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrTileCache.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrTileCache.java
@@ -43,4 +43,9 @@ public class OmeZarrTileCache  extends BasicTileCache<OmeZarrBlockTileKey, Sorta
         }
         group.clear();
     }
+
+    @Override
+    protected String getTileName(OmeZarrBlockTileKey key) {
+        return key.getRelativePath();
+    }
 }

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/loader/OmeZarrLoader.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/loader/OmeZarrLoader.java
@@ -2,7 +2,6 @@ package org.janelia.horta.loader;
 
 import org.apache.commons.io.FilenameUtils;
 import org.janelia.horta.NeuronTracerTopComponent;
-import org.janelia.horta.volume.StaticVolumeBrickSource;
 
 import java.io.IOException;
 

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/omezarr/OmeZarrReaderCompletionObserver.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/omezarr/OmeZarrReaderCompletionObserver.java
@@ -1,0 +1,7 @@
+package org.janelia.horta.omezarr;
+
+import org.janelia.horta.blocks.OmeZarrBlockTileSource;
+
+public interface OmeZarrReaderCompletionObserver {
+    void complete(OmeZarrBlockTileSource source);
+}

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/omezarr/OmeZarrReaderProgressObserver.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/omezarr/OmeZarrReaderProgressObserver.java
@@ -1,0 +1,7 @@
+package org.janelia.horta.omezarr;
+
+import org.janelia.horta.blocks.OmeZarrBlockTileSource;
+
+public interface OmeZarrReaderProgressObserver {
+    void update(OmeZarrBlockTileSource source, String progress);
+}


### PR DESCRIPTION
Addresses an issue with large samples (full brain size) with small chunks (128x128x128 or smaller).

- Removed some object allocations to reduce load on GC
- Add progress updates during load
- Parse the metadata off the UI thread
- Display lower resolution paths as they are available rather than waiting for all paths to load

There is one small change to non-OME-Zarr content. `BasicTileCache.java` was hard-coded to use toString() as the key for the map and for messages.  This is an expensive operation for OME-Zarr tiles as compared to other formats due to the content we want presented by other parts of the Workstation general code that use it (e.g., tile loading messages).  `BasicTileCache` is a base class so this was changed to method to get the key that defaults to using toString() so existing implementations remain unchanged.  The OME-Zarr implementation uses a different method.

This makes the samples loadable, however a future update will be required to reduce the load time further.