### PR TITLE
Improve OME-Zarr load performance.

### DIFF
--- a/modules/HortaTracer/pom.xml
+++ b/modules/HortaTracer/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.aind</groupId>
             <artifactId>jomezarr</artifactId>
-            <version>1.2.11</version>
+            <version>1.3.0</version>
         </dependency>
         
         <!-- NetBeans Modules --> 

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/actors/OmeZarrVolumeMeshActor.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/actors/OmeZarrVolumeMeshActor.java
@@ -45,7 +45,7 @@ public class OmeZarrVolumeMeshActor extends MeshActor implements SortableBlockAc
 
         this.homogeneousCentroid = new Vector4(centroid.getX(), centroid.getY(), centroid.getZ(), 1.0f);
 
-        resolution = new OmeZarrBlockResolution(tile.getKeyDepth(), tile.getShape(), tile.getVoxelSize(), tile.getResolutionMicrometers());
+        resolution = new OmeZarrBlockResolution(tile.getDataset(), tile.getKeyDepth(), tile.getShape(), tile.getVoxelSize(), tile.getResolutionMicrometers());
 
         bbox_min = tile.getOrigin();
         Vector3 ext = tile.getExtents();

--- a/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockResolution.java
+++ b/modules/HortaTracer/src/main/java/org/janelia/horta/blocks/OmeZarrBlockResolution.java
@@ -1,5 +1,7 @@
 package org.janelia.horta.blocks;
 
+import org.aind.omezarr.OmeZarrDataset;
+
 public class OmeZarrBlockResolution implements BlockTileResolution {
     private final int depth;
 
@@ -11,7 +13,10 @@ public class OmeZarrBlockResolution implements BlockTileResolution {
 
     private final OmeZarrBlockInfoSet blockInfoSet;
 
-    public OmeZarrBlockResolution(int depth, int[] chunkSizeXYZ, double[] voxelSize, double resolutionMicrometers) {
+    private final OmeZarrDataset dataset;
+
+    public OmeZarrBlockResolution(OmeZarrDataset dataset, int depth, int[] chunkSizeXYZ, double[] voxelSize, double resolutionMicrometers) {
+        this.dataset = dataset;
         this.depth = depth;
         this.chunkSizeXYZ = chunkSizeXYZ;
         this.resolutionMicrometers = resolutionMicrometers;
@@ -27,6 +32,14 @@ public class OmeZarrBlockResolution implements BlockTileResolution {
 
     public int getDepth() {
         return depth;
+    }
+
+    public OmeZarrDataset getDataset() {
+        return dataset;
+    }
+
+    public double[] getVoxelSize() {
+        return voxelSize;
     }
 
     @Override


### PR DESCRIPTION
Updates OME-Zarr loading.  Existing code used static tile loading behavior, creating a with a K-D Tree for tile key lookup at initial load.  This is unnecessary with OME-Zarr with its fixed grid.  Tile keys are now generated dynamically when requested.  Note: This requires an updated jomezarr (1.3.0).