### PR TITLE
GitHub error reporting

### DIFF
--- a/modules/CommonGUI/src/main/java/org/janelia/workstation/common/nb_action/ReportABugMenuAction.java
+++ b/modules/CommonGUI/src/main/java/org/janelia/workstation/common/nb_action/ReportABugMenuAction.java
@@ -5,7 +5,7 @@ import java.awt.event.ActionEvent;
 import javax.swing.AbstractAction;
 
 import org.janelia.workstation.core.logging.LoggingUtils;
-import org.janelia.workstation.core.util.MailDialogueBox;
+import org.janelia.workstation.core.util.ErrorReportDialogueBox;
 import org.janelia.workstation.integration.util.FrameworkAccess;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
@@ -27,9 +27,9 @@ public final class ReportABugMenuAction extends AbstractAction {
     @Override
     public void actionPerformed(ActionEvent e) {
 
-        String subject = LoggingUtils.getReportEmailSubject(false)+" -- Bug Report";
+        String subject = LoggingUtils.getErrorReportSubject(false)+" -- Bug Report";
 
-        MailDialogueBox popup = MailDialogueBox.newDialog(FrameworkAccess.getMainFrame())
+        ErrorReportDialogueBox popup = ErrorReportDialogueBox.newDialog(FrameworkAccess.getMainFrame())
                 .withTitle("Create A Ticket")
                 .withPromptText("Problem Description:")
                 .withEmailSubject(subject)

--- a/modules/CommonGUI/src/main/java/org/janelia/workstation/common/nb_action/ReportABugMenuAction.java
+++ b/modules/CommonGUI/src/main/java/org/janelia/workstation/common/nb_action/ReportABugMenuAction.java
@@ -32,14 +32,14 @@ public final class ReportABugMenuAction extends AbstractAction {
         ErrorReportDialogueBox popup = ErrorReportDialogueBox.newDialog(FrameworkAccess.getMainFrame())
                 .withTitle("Create A Ticket")
                 .withPromptText("Problem Description:")
-                .withEmailSubject(subject)
+                .withSubject(subject)
                 .appendStandardPrefix()
                 .append("\n\nMessage:\n");
         
         String desc = popup.showPopup();
         if (desc!=null) {
             popup.appendLine(desc);
-            popup.sendEmail();
+            popup.sendReport();
         }
         
     }

--- a/modules/Core/src/main/java/org/janelia/workstation/core/logging/LoggingUtils.java
+++ b/modules/Core/src/main/java/org/janelia/workstation/core/logging/LoggingUtils.java
@@ -8,7 +8,7 @@ import org.janelia.workstation.core.util.SystemInfo;
  */
 public class LoggingUtils {
 
-    public static String getReportEmailSubject(boolean isAutoReport) {
+    public static String getErrorReportSubject(boolean isAutoReport) {
 
         AccessManager accessManager = AccessManager.getAccessManager();
 

--- a/modules/Core/src/main/java/org/janelia/workstation/core/logging/NBExceptionHandler.java
+++ b/modules/Core/src/main/java/org/janelia/workstation/core/logging/NBExceptionHandler.java
@@ -9,7 +9,7 @@ import com.google.common.util.concurrent.RateLimiter;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.janelia.workstation.core.api.AccessManager;
 import org.janelia.workstation.core.util.ConsoleProperties;
-import org.janelia.workstation.core.util.MailDialogueBox;
+import org.janelia.workstation.core.util.ErrorReportDialogueBox;
 import org.janelia.workstation.core.util.SystemInfo;
 import org.janelia.workstation.integration.util.FrameworkAccess;
 import org.slf4j.Logger;
@@ -194,30 +194,30 @@ public class NBExceptionHandler extends Handler implements Callable<JButton>, Ac
         try {
             String firstLine = getSummary(stacktrace);
             log.info("Reporting exception: "+firstLine);
-            String subject = LoggingUtils.getReportEmailSubject(!askForInput)+" -- "+firstLine;
+            String subject = LoggingUtils.getErrorReportSubject(!askForInput)+" -- "+firstLine;
 
-            MailDialogueBox mailDialogueBox = MailDialogueBox.newDialog(FrameworkAccess.getMainFrame())
+            ErrorReportDialogueBox errorReportDialogueBox = ErrorReportDialogueBox.newDialog(FrameworkAccess.getMainFrame())
                     .withTitle("Create A Ticket")
                     .withPromptText("If possible, please describe what you were doing when the error occurred:")
                     .withEmailSubject(subject)
                     .appendStandardPrefix();
             
             if (askForInput) {
-                String problemDesc = mailDialogueBox.showPopup();
+                String problemDesc = errorReportDialogueBox.showPopup();
                 if (problemDesc==null) {
                     // User pressed cancel
                     return;
                 }
                 else {
-                    mailDialogueBox.append("\n\nProblem Description:\n");
-                    mailDialogueBox.append(problemDesc);
+                    errorReportDialogueBox.append("\n\nProblem Description:\n");
+                    errorReportDialogueBox.append(problemDesc);
                 }
             }
 
-            mailDialogueBox.append("\n\nStack Trace:\n");
-            mailDialogueBox.append(stacktrace);
+            errorReportDialogueBox.append("\n\nStack Trace:\n");
+            errorReportDialogueBox.append(stacktrace);
             
-            mailDialogueBox.sendEmail();
+            errorReportDialogueBox.sendEmail();
         }
         catch (Exception ex) {
             log.warn("Error sending exception email",ex);

--- a/modules/Core/src/main/java/org/janelia/workstation/core/util/ErrorReportDialogueBox.java
+++ b/modules/Core/src/main/java/org/janelia/workstation/core/util/ErrorReportDialogueBox.java
@@ -31,6 +31,7 @@ public class ErrorReportDialogueBox {
     private static final String ISSUES_BRANCH = "issues";
     private static final String ATTACHMENTS_FOLDER = "attachments";
 
+    private static final String SUBJECT_PREFIX = "[JW] ";
 
     private String subject = "";
     private String initialBody = "";
@@ -63,6 +64,9 @@ public class ErrorReportDialogueBox {
     }
     
     public ErrorReportDialogueBox withSubject(String subject) {
+        if (!subject.startsWith(SUBJECT_PREFIX)) {
+            subject = SUBJECT_PREFIX + subject;
+        }
         this.subject = subject;
         return this;
     }

--- a/modules/Core/src/main/java/org/janelia/workstation/core/util/ErrorReportDialogueBox.java
+++ b/modules/Core/src/main/java/org/janelia/workstation/core/util/ErrorReportDialogueBox.java
@@ -117,8 +117,9 @@ public class ErrorReportDialogueBox {
     public void sendReport() {
         String method = ConsoleProperties.getString("console.ErrorReportingMethod", null);
         if (method == null) {
-            log.error("Cannot send error report; no value for console.ErrorReportingMethod is configured");
-            return;
+            // "email" was our original implementation, so if unset, default to "email" for
+            //  backward compatibility
+            method = "email";
         }
 
         if (method.equals("email")) {

--- a/modules/Core/src/main/java/org/janelia/workstation/core/util/ErrorReportDialogueBox.java
+++ b/modules/Core/src/main/java/org/janelia/workstation/core/util/ErrorReportDialogueBox.java
@@ -23,9 +23,9 @@ import org.slf4j.LoggerFactory;
  * @author kimmelr
  * @author <a href="mailto:rokickik@janelia.hhmi.org">Konrad Rokicki</a>
  */
-public class MailDialogueBox {
+public class ErrorReportDialogueBox {
 
-    private static final Logger log = LoggerFactory.getLogger(MailDialogueBox.class);
+    private static final Logger log = LoggerFactory.getLogger(ErrorReportDialogueBox.class);
 
     private static final String LOG_FILE_NAME = "messages.log";
 
@@ -36,40 +36,40 @@ public class MailDialogueBox {
     private StringBuffer body = new StringBuffer();
     private JFrame parentFrame;
 
-    private MailDialogueBox(JFrame parentFrame) {
+    private ErrorReportDialogueBox(JFrame parentFrame) {
         this.parentFrame = parentFrame;
     }
     
-    public static MailDialogueBox newDialog(JFrame parentFrame) {
-        return new MailDialogueBox(parentFrame);
+    public static ErrorReportDialogueBox newDialog(JFrame parentFrame) {
+        return new ErrorReportDialogueBox(parentFrame);
     }
 
-    public MailDialogueBox withTitle(String title) {
+    public ErrorReportDialogueBox withTitle(String title) {
         this.title = title;
         return this;
     }
 
-    public MailDialogueBox withPromptText(String promptText) {
+    public ErrorReportDialogueBox withPromptText(String promptText) {
         this.promptText = promptText;
         return this;
     }
 
-    public MailDialogueBox withTextAreaBody(String initialBody) {
+    public ErrorReportDialogueBox withTextAreaBody(String initialBody) {
         this.initialBody = initialBody;
         return this;
     }
     
-    public MailDialogueBox withEmailSubject(String subject) {
+    public ErrorReportDialogueBox withEmailSubject(String subject) {
         this.subject = subject;
         return this;
     }
 
-    public MailDialogueBox append(String str) {
+    public ErrorReportDialogueBox append(String str) {
         body.append(str);
         return this;
     }
     
-    public MailDialogueBox appendStandardPrefix() {
+    public ErrorReportDialogueBox appendStandardPrefix() {
         append("\nSubject: ").append(AccessManager.getSubjectKey());
         append("\nApplication: ").append(SystemInfo.appName).append(" v").append(SystemInfo.appVersion);
         append("\nServer: ").append(ConnectionMgr.getConnectionMgr().getConnectionString());
@@ -88,7 +88,7 @@ public class MailDialogueBox {
         return this;
     }
 
-    public MailDialogueBox appendLine(String str) {
+    public ErrorReportDialogueBox appendLine(String str) {
         body.append(str).append("\n");
         return this;
     }

--- a/modules/Core/src/main/java/org/janelia/workstation/core/util/GitHubRestClient.java
+++ b/modules/Core/src/main/java/org/janelia/workstation/core/util/GitHubRestClient.java
@@ -1,0 +1,147 @@
+package org.janelia.workstation.core.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.ws.rs.client.*;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.List;
+import java.util.Scanner;
+
+public class GitHubRestClient {
+    private static final Logger logger = LoggerFactory.getLogger(GitHubRestClient.class);
+
+    private final String projectURL;
+    private final String accessToken;
+
+    private Client client;
+
+    public GitHubRestClient() {
+        this.projectURL = ConsoleProperties.getInstance().getProperty("console.GitHubErrorProjectURL");
+        this.accessToken = ConsoleProperties.getInstance().getProperty("console.GitHubErrorProjectAccessToken");
+        logger.debug("Using project URL: {}", this.projectURL);
+
+        client = ClientBuilder.newClient();
+    }
+
+    private Invocation.Builder getBuilder(String path) {
+        WebTarget baseTarget = client.target(projectURL);
+        WebTarget pathTarget = baseTarget.path(path);
+        return pathTarget.request(MediaType.APPLICATION_JSON).header(HttpHeaders.AUTHORIZATION, "Bearer " + accessToken);
+    }
+
+    // this method is for testing and debugging
+    public List<String> getIssueList() {
+        List<String> issues = new ArrayList<>();
+
+        Response response = getBuilder("issues").get();
+        if (response.getStatus() != Response.Status.OK.getStatusCode()) {
+            logger.error("Error getting issues list; status {}, body {}", response.getStatus(), response.readEntity(String.class));
+            return issues;
+        }
+
+        String json = response.readEntity(String.class);
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            JsonNode nodes = mapper.readValue(json, JsonNode.class);
+            for (JsonNode node: nodes) {
+                issues.add(node.at("/title").asText());
+            }
+        } catch (JsonProcessingException e) {
+            logger.error("Error parsing json for issues list");
+            return issues;
+        }
+
+        return issues;
+    }
+
+    public int createIssue(String title, String body) {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode newIssue = mapper.createObjectNode();
+        newIssue.put("title", title);
+        newIssue.put("body", body);
+
+        Response response = getBuilder("issues").post(Entity.json(newIssue));
+        if (response.getStatus() != Response.Status.CREATED.getStatusCode()) {
+            logger.error("Error creating new issue; status {}, body {}", response.getStatus(), response.readEntity(String.class));
+            return 0;
+        }
+
+        String json = response.readEntity(String.class);
+        try {
+            ObjectMapper mapper2 = new ObjectMapper();
+            JsonNode node = mapper2.readTree(json);
+            if (!node.has("number")) {
+                logger.error("Returned json doesn't contain issue number");
+                return 0;
+            }
+            return Integer.parseInt(node.get("number").asText());
+        } catch (JsonProcessingException e) {
+            logger.error("Error parsing json for created issue");
+            return 0;
+        }
+    }
+
+    public String uploadLogFile(String branch, File logfile, String path) {
+        String unencodedLog = "";
+        try (Scanner scanner = new Scanner(logfile)) {
+            unencodedLog = scanner.useDelimiter("\\A").next();
+        } catch (IOException e) {
+            logger.error("Error reading log file");
+            return "";
+        }
+        String encodedLog = Base64.getEncoder().encodeToString(unencodedLog.getBytes());
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode upload = mapper.createObjectNode();
+        upload.put("message", "uploaded attachment");
+        upload.put("branch", branch);
+        upload.put("content", encodedLog);
+
+        Response response = getBuilder("contents/" + path).put(Entity.json(upload));
+        if (response.getStatus() != Response.Status.CREATED.getStatusCode()) {
+            logger.error("Error uploading logfile; status {}, body {}", response.getStatus(), response.readEntity(String.class));
+            return "";
+        }
+
+        // generate permalink to the uploaded file
+        String json = response.readEntity(String.class);
+        String permalink = "";
+        try {
+            ObjectMapper mapper2 = new ObjectMapper();
+            JsonNode tree = mapper2.readTree(json);
+            String sha = tree.at("/commit/sha").asText();
+            permalink = projectURL.replace("api.", "").replace("/repos", "") +
+                    "/blob/" + sha + "/" + path;
+        } catch (JsonProcessingException e) {
+            logger.error("Error parsing json from logfile upload");
+            return "";
+        }
+        return permalink;
+    }
+
+    public boolean addComment(int issueId, String comment) {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode commentNode = mapper.createObjectNode();
+        commentNode.put("body", comment);
+
+        Response response = getBuilder("issues/" + issueId + "/comments").post(Entity.json(commentNode));
+        if (response.getStatus() != Response.Status.CREATED.getStatusCode()) {
+            logger.error("Error adding comment; status {}, body {}", response.getStatus(), response.readEntity(String.class));
+            return false;
+        } else {
+            return true;
+        }
+    }
+
+}

--- a/modules/Core/src/main/java/org/janelia/workstation/core/util/MailHelper.java
+++ b/modules/Core/src/main/java/org/janelia/workstation/core/util/MailHelper.java
@@ -64,7 +64,7 @@ public class MailHelper {
             Message message = new MimeMessage(session);
             message.setFrom(new InternetAddress(from));
             message.setRecipients(RecipientType.TO, InternetAddress.parse(to));
-            message.setSubject("[JW] " + subject);
+            message.setSubject(subject);
             BodyPart messagePart = new MimeBodyPart();
             messagePart.setText(bodyText);
             Multipart multipart = new MimeMultipart();

--- a/modules/Core/src/main/java/org/janelia/workstation/core/util/MailHelper.java
+++ b/modules/Core/src/main/java/org/janelia/workstation/core/util/MailHelper.java
@@ -23,11 +23,11 @@ public class MailHelper {
     public MailHelper() {
     }
 
-    public void sendEmail(String from, String to, String subject, String bodyText) {
-        this.sendEmail(from, to, subject, bodyText, null, null);
+    public boolean sendEmail(String from, String to, String subject, String bodyText) {
+        return this.sendEmail(from, to, subject, bodyText, null, null);
     }
 
-    public void sendEmail(String from, String to, String subject, String bodyText, File attachedFile, String filename) {
+    public boolean sendEmail(String from, String to, String subject, String bodyText, File attachedFile, String filename) {
         try {
             String mailServer = ConsoleProperties.getString("console.MailServer");
             String mailUser = ConsoleProperties.getString("console.MailUser", "");
@@ -88,9 +88,12 @@ public class MailHelper {
             log.info("  To: " + to);
             log.info("  Body: " + bodyText);
 
+            return true;
+
         }
         catch (MessagingException var13) {
             log.error("Error sending email", var13);
+            return false;
         }
 
     }

--- a/modules/LMDataBrowser/src/main/java/org/janelia/workstation/lm/actions/context/ReportProblemAction.java
+++ b/modules/LMDataBrowser/src/main/java/org/janelia/workstation/lm/actions/context/ReportProblemAction.java
@@ -5,7 +5,9 @@ import org.janelia.model.domain.sample.Sample;
 import org.janelia.workstation.common.actions.BaseContextualNodeAction;
 import org.janelia.workstation.core.activity_logging.ActivityLogHelper;
 import org.janelia.workstation.core.api.AccessManager;
+import org.janelia.workstation.core.logging.LoggingUtils;
 import org.janelia.workstation.core.util.ConsoleProperties;
+import org.janelia.workstation.core.util.ErrorReportDialogueBox;
 import org.janelia.workstation.core.util.MailHelper;
 import org.janelia.workstation.integration.util.FrameworkAccess;
 import org.openide.awt.ActionID;
@@ -45,8 +47,7 @@ public class ReportProblemAction extends BaseContextualNodeAction {
         if (getNodeContext().isSingleObjectOfType(Sample.class)) {
             this.selectedObject = getNodeContext().getSingleObjectOfType(Sample.class);
             setEnabledAndVisible(true);
-        }
-        else {
+        } else {
             setEnabledAndVisible(false);
         }
     }
@@ -61,66 +62,37 @@ public class ReportProblemAction extends BaseContextualNodeAction {
             reportData(domainObject);
 
             JOptionPane.showMessageDialog(FrameworkAccess.getMainFrame(),
-                    "Successfully reported problem with "+domainObject.getName(),
+                    "Successfully reported problem with " + domainObject.getName(),
                     "Data Problem Reported", JOptionPane.PLAIN_MESSAGE);
-        }
-        catch (Exception ex) {
+        } catch (Exception ex) {
             FrameworkAccess.handleException(ex);
         }
     }
 
     private void reportData(DomainObject domainObject) {
 
-        String fromEmail = ConsoleProperties.getString("console.FromEmail", null);
-        if (fromEmail==null) {
-            log.error("Cannot send exception report: no value for console.FromEmail is configured.");
-            return;
-        }
+        String subject = "Reported Data: " + domainObject.getName();
 
-        String toEmail = ConsoleProperties.getString("console.HelpEmail", null);
-        if (toEmail==null) {
-            log.error("Cannot send exception report: no value for console.HelpEmail is configured.");
-            return;
-        }
+        // this dialog box will not be displayed; we do not call errorReportDialogueBox.showPopup()
+        ErrorReportDialogueBox errorReportDialogueBox = ErrorReportDialogueBox.newDialog(FrameworkAccess.getMainFrame())
+                .withTitle("not displayed")
+                .withPromptText("not displayed")
+                .withEmailSubject(subject);
 
-        DataReporter reporter = new DataReporter(fromEmail, toEmail);
-        reporter.reportData(domainObject, null);
+        errorReportDialogueBox.append(createEntityReport(domainObject));
+        errorReportDialogueBox.sendEmail();
     }
 
-    public static class DataReporter {
+    private String createEntityReport(DomainObject domainObject) {
+        StringBuilder sBuf = new StringBuilder();
 
-        private final String fromEmail;
-        private final String toEmail;
+        String user = AccessManager.getSubjectKey();
+        sBuf.append("Reporting user: ").append(user).append("\n");
 
-        public DataReporter(String fromEmail, String toEmail) {
-            this.fromEmail = fromEmail;
-            this.toEmail = toEmail;
-        }
-
-        private String createEntityReport(DomainObject domainObject, String annotation) {
-            StringBuilder sBuf = new StringBuilder();
-
-            String user = AccessManager.getSubjectKey();
-            sBuf.append("Reporting user: ").append(user).append("\n");
-
-            sBuf.append("GUID: ").append(domainObject.getId().toString()).append("\n");
-            sBuf.append("Type: ").append(domainObject.getType()).append("\n");
-            sBuf.append("Owner: ").append(domainObject.getOwnerKey()).append("\n");
-            sBuf.append("Name: ").append(domainObject.getName()).append("\n");
-            if (annotation!=null) {
-                sBuf.append("Annotation: ").append(annotation).append("\n\n");
-            }
-            return sBuf.toString();
-        }
-
-        public void reportData(DomainObject domainObject, String annotation) {
-            String subject = "Reported Data: " + domainObject.getName();
-            if (annotation!=null) {
-                subject += " ("+annotation+")";
-            }
-            String report = createEntityReport(domainObject, annotation);
-            MailHelper helper = new MailHelper();
-            helper.sendEmail(fromEmail, toEmail, subject, report);
-        }
+        sBuf.append("GUID: ").append(domainObject.getId().toString()).append("\n");
+        sBuf.append("Type: ").append(domainObject.getType()).append("\n");
+        sBuf.append("Owner: ").append(domainObject.getOwnerKey()).append("\n");
+        sBuf.append("Name: ").append(domainObject.getName()).append("\n");
+        return sBuf.toString();
     }
 }

--- a/modules/LMDataBrowser/src/main/java/org/janelia/workstation/lm/actions/context/ReportProblemAction.java
+++ b/modules/LMDataBrowser/src/main/java/org/janelia/workstation/lm/actions/context/ReportProblemAction.java
@@ -5,10 +5,7 @@ import org.janelia.model.domain.sample.Sample;
 import org.janelia.workstation.common.actions.BaseContextualNodeAction;
 import org.janelia.workstation.core.activity_logging.ActivityLogHelper;
 import org.janelia.workstation.core.api.AccessManager;
-import org.janelia.workstation.core.logging.LoggingUtils;
-import org.janelia.workstation.core.util.ConsoleProperties;
 import org.janelia.workstation.core.util.ErrorReportDialogueBox;
-import org.janelia.workstation.core.util.MailHelper;
 import org.janelia.workstation.integration.util.FrameworkAccess;
 import org.openide.awt.ActionID;
 import org.openide.awt.ActionReference;
@@ -77,10 +74,10 @@ public class ReportProblemAction extends BaseContextualNodeAction {
         ErrorReportDialogueBox errorReportDialogueBox = ErrorReportDialogueBox.newDialog(FrameworkAccess.getMainFrame())
                 .withTitle("not displayed")
                 .withPromptText("not displayed")
-                .withEmailSubject(subject);
+                .withSubject(subject);
 
         errorReportDialogueBox.append(createEntityReport(domainObject));
-        errorReportDialogueBox.sendEmail();
+        errorReportDialogueBox.sendReport();
     }
 
     private String createEntityReport(DomainObject domainObject) {

--- a/modules/ViewerInfoPanel/src/main/java/org/janelia/workstation/infopanel/WorkspaceInfoPanel.java
+++ b/modules/ViewerInfoPanel/src/main/java/org/janelia/workstation/infopanel/WorkspaceInfoPanel.java
@@ -58,7 +58,7 @@ public class WorkspaceInfoPanel extends JPanel {
      */
     private void updateMetaData(final TmWorkspace workspace) {
         if (TmModelManager.getInstance().getCurrentSample() == null) {
-            setSampleName("(no sample");
+            setSampleName("(no sample)");
             setWorkspaceName("(no workspace)", false);
             return;
         } else {


### PR DESCRIPTION
# Goal: add another option for error reporting in the workstation

In the workstation, we currently provide error reporting (automatic and user-driven) via email, in our case, to JIRA. This works in the cloud and the thick client. This may not be as useful for other installations outside Janelia. Even within Janelia, we are gradually shifting away from JIRA use.

GitHub is the de facto default issue tracker that everyone has easy access to. This set of changes implements error reporting to a GitHub issue tracker as an option for the workstation. The existing email reporting is not removed and is still the default option.

The feature is working in my hands on my machine, but I need help with getting configuration of the properties files working, especially in the cloud. The same branch name (`github-error-reporting`) is used in this repo as well as `jacs-cm` and `hortacloud-website`. The branches are up to date with approx. v9.21.

These pull requests in the other repos just contain a link back to this pull request:
- JaneliaSciComp/hortacloud-website#25
- JaneliaSciComp/jacs-cm#37

# Implementation

Basically I created a `GitHubRestClient` which provides the same interface as the existing `MailHelper`, and I generalized all the sources of error reports to be able to feed either one.

Access is controlled via a fine-grained personal access token to a GitHub repo created for this purpose (not the main code repo, for various reasons). This has to be created by an appropriate GitHub account, either a service account or a developer account. 

Two features of GitHub create slight annoyances. First, issue text limits makes it impossible to include our system logs in-line. Second, the GitHub API inexplicably doesn't allow the creation of attachments on issues at all, even though that's an option for a human in the web UI. As a result, the system log is instead uploaded as a file on a branch in the repo, and a link is created in a comment on the issue.


# Configuration

Error reporting is entirely client-side, controlled through values in `console.properties`. Values can be fed in the same way they are for email reporting. The new values look like this (excerpt from `client.properties` in `jacs-cm`):

```shell
# Error reporting
# valid ErrorReportingMethod options: email, github
# console.ErrorReportingMethod=email
console.ErrorReportingMethod=github
console.AutoSendExceptions=true

# GitHub
console.GitHubErrorProjectURL=${GITHUB_URL}
console.GitHubErrorProjectAccessToken=${GITHUB_TOKEN}
```

I will provide a URL and token for testing in Slack.

See `ErrorReporting.md` in `hortacloud-website` on the `github-error-reporting` branch for more details.

## Testing

If you put the above lines in `my.properties` (with values) and build, it will report errors to the given repository.

I'm not set up to test how the values are passed along for either the thick client build or cloud deployment. I've made a start of it in `jacs-cm`, but this needs someone else to finish it up and test it.

# Deployment

After merging but before deployment, we'll need to create and configure a GitHub repository for errors. We'll need to decide which GitHub account to use and generate the token. I can do the work once those decisions are made.

Deployment probably needs its own tracking issue and checklist, once the code is ready.