### PR TITLE
fix NPE in blank 3d view; no sample = no notifications

### DIFF
--- a/modules/SceneWindow/src/main/java/org/janelia/scenewindow/SceneInteractor.java
+++ b/modules/SceneWindow/src/main/java/org/janelia/scenewindow/SceneInteractor.java
@@ -37,6 +37,10 @@ implements MouseListener, MouseMotionListener, MouseWheelListener
     public abstract String getToolTipText();
     
     public void notifyObservers() {
+        if (TmModelManager.getInstance().getCurrentSample() == null)
+            // no sample, no notifications
+            return;
+
         camera.getVantage().notifyObservers();
         Vantage vantage = camera.getVantage();
         Matrix m2v = TmModelManager.getInstance().getMicronToVoxMatrix();


### PR DESCRIPTION
Added a check for no sample to prevent NPE when interacting with (scroll wheel) a blank 3d window.

Fixes JW-52721. Also reported by AIND in Slack.

@porterbot, you can merge when you approve.

@stuarteberg 