### PR TITLE
fix null pointer; domainObject was not set before use in some cases

### DIFF
--- a/modules/ViewerController/src/main/java/org/janelia/workstation/controller/action/DeleteHortaWorkspaceAction.java
+++ b/modules/ViewerController/src/main/java/org/janelia/workstation/controller/action/DeleteHortaWorkspaceAction.java
@@ -53,10 +53,12 @@ public class DeleteHortaWorkspaceAction extends BaseContextualNodeAction {
     @Override
     protected void processContext() {
         if (getNodeContext().isSingleObjectOfType(TmWorkspace.class)) {
+            domainObject = getNodeContext().getSingleObjectOfType(TmWorkspace.class);
             if (AccessManager.getAccessManager().isAdmin() ||
                     domainObject.getOwnerKey().equals(AccessManager.getSubjectKey())) {
-                domainObject = getNodeContext().getSingleObjectOfType(TmWorkspace.class);
                 setEnabledAndVisible(true);
+            } else {
+                setEnabledAndVisible(false);
             }
         }
         else {


### PR DESCRIPTION
This fixes JW-52979 in our internal tracker. Error is below for reference. The error is invisible to the user. It happens when clicking on a workspace in the explorer to determine if it is eligible to have the "Delete Workspace" item on its right-click menu.

In the wild, I can't reproduce this bug on command. But it's appeared several times to Mary and Nataliia. Inspection of the code reveals the _likely_ cause: domainObject was sometimes unset before use. I fixed it and verified that the menu item does appear when it should.

@porterbot should definitely review this, as he wrote the original. David should feel free to merge if he approves.

Also @krokicki for general workstation insight, and @stuarteberg because he loves Java.

Error so you don't have to look up the issue:

```
    java.lang.NullPointerException
    at org.janelia.workstation.controller.action.DeleteHortaWorkspaceAction.processContext(DeleteHortaWorkspaceAction.java:57)
    at org.janelia.workstation.common.actions.BaseContextualNodeAction.enable(BaseContextualNodeAction.java:101)
    at org.janelia.workstation.core.actions.ContextualNodeActionTracker.resultChanged(ContextualNodeActionTracker.java:80)
    at org.openide.util.lookup.SimpleProxyLookup.checkLookup(SimpleProxyLookup.java:114)
    at org.openide.util.lookup.SimpleProxyLookup.lookup(SimpleProxyLookup.java:159)
    at org.netbeans.modules.openide.windows.GlobalActionContextImpl.propertyChange(GlobalActionContextImpl.java:194)
    at java.beans.PropertyChangeSupport.fire(PropertyChangeSupport.java:335)
    at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:327)
    at java.beans.PropertyChangeSupport.firePropertyChange(PropertyChangeSupport.java:263)
    at org.netbeans.core.windows.RegistryImpl.doFirePropertyChange(RegistryImpl.java:329)
    at org.netbeans.core.windows.RegistryImpl.access$100(RegistryImpl.java:69)
    at org.netbeans.core.windows.RegistryImpl$1.run(RegistryImpl.java:170)
    at java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:311)
    at java.awt.EventQueue.dispatchEventImpl(EventQueue.java:758)
    at java.awt.EventQueue.access$500(EventQueue.java:97)
    at java.awt.EventQueue$3.run(EventQueue.java:709)
    at java.awt.EventQueue$3.run(EventQueue.java:703)
    at java.security.AccessController.doPrivileged(Native Method)
    at java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:74)
    at java.awt.EventQueue.dispatchEvent(EventQueue.java:728)
    at org.janelia.workstation.common.logging.EDTExceptionInterceptor.dispatchEvent(EDTExceptionInterceptor.java:21)
    at java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:205)
    at java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:116)
    at java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:105)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
    at java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:93)
    at java.awt.EventDispatchThread.run(EventDispatchThread.java:82)
```