### PR TITLE
JOmeZarr v1.4.3

### DIFF
--- a/modules/HortaTracer/pom.xml
+++ b/modules/HortaTracer/pom.xml
@@ -78,10 +78,10 @@
         <dependency>
             <groupId>org.aind</groupId>
             <artifactId>jomezarr</artifactId>
-            <version>1.4.2</version>
+            <version>1.4.3</version>
         </dependency>
         <dependency>
-            <groupId>com.bc.zarr</groupId>
+            <groupId>dev.zarr</groupId>
             <artifactId>jzarr</artifactId>
             <version>0.4.6</version>
         </dependency>


### PR DESCRIPTION
JOmeZarr v1.4.3 provides more flexible loading of OME-Zarr .zattrs files that contain elements not specifically defined in the spec.  This is a [relatively small](https://github.com/AllenNeuralDynamics/jomezarr/commit/96f128922d25066301ce0691855f906e89c5b2be) change.

It also references the new package name for the jzarr library which was transferred to a new group.

org.aind.jomezarr 1.4.3 and dev.zarr.jzarr 0.4.6 are attached or can be built from these repositories and branches:

- jomezarr: https://github.com/AllenNeuralDynamics/jomezarr (main)
- jzarr: https://github.com/AllenNeuralDynamics/jzarr/tree/zstd (zstd)


[org.aind.jomezrr-1.4.3.zip](https://github.com/user-attachments/files/26004863/org.aind.jomezrr-1.4.3.zip)
[dev.zarr.jzarr-0.4.6.zip](https://github.com/user-attachments/files/26004865/dev.zarr.jzarr-0.4.6.zip)
